### PR TITLE
Improve polyline coords calculation for PieArcLabel

### DIFF
--- a/src/PieChart/PieArcSeries/PieArcLabel.tsx
+++ b/src/PieChart/PieArcSeries/PieArcLabel.tsx
@@ -44,13 +44,31 @@ export class PieArcLabel extends PureComponent<PieArcLabelProps> {
     const textAnchor = getTextAnchor(data);
     const [posX, posY] = position;
 
-    const innerLinePos = centroid(data);
-    let scale = posY / innerLinePos[1];
-    if (posY === 0 || innerLinePos[1] === 0) {
-      scale = 1;
-    }
+    const innerPoint = centroid(data);
 
-    const outerPos = [scale * innerLinePos[0], scale * innerLinePos[1]];
+    let breakPoint = [0, 0];
+    // whether we should create breakpoint near pie or near label
+    const breakPointCondition =
+      (posY - innerPoint[1]) * Math.sign(innerPoint[1]) > 0;
+
+    if (breakPointCondition) {
+      // extend the line starting from innerPoint till the posY
+      let scale = Math.abs(posY / innerPoint[1]) || 1;
+      const minScale = 1;
+      const maxScale = Math.abs(posX / innerPoint[0]) || 1;
+
+      scale = Math.max(Math.min(maxScale, scale), minScale);
+
+      breakPoint = [innerPoint[0] * scale, posY];
+    } else {
+      let scale = 0.85;
+      const minScale = Math.abs(innerPoint[0] / posX) || 1;
+      const maxScale = 1;
+
+      scale = Math.max(Math.min(maxScale, scale), minScale);
+
+      breakPoint = [posX * scale, innerPoint[1]];
+    }
 
     return (
       <motion.g
@@ -78,7 +96,7 @@ export class PieArcLabel extends PureComponent<PieArcLabelProps> {
         <polyline
           fill="none"
           stroke={lineStroke}
-          points={`${innerLinePos},${outerPos},${posX} ${posY}`}
+          points={`0,0,${[innerPoint]},${breakPoint},${position}`}
         />
       </motion.g>
     );

--- a/src/PieChart/PieArcSeries/PieArcSeries.tsx
+++ b/src/PieChart/PieArcSeries/PieArcSeries.tsx
@@ -147,7 +147,9 @@ export class PieArcSeries extends Component<PieArcSeriesProps> {
     const innerArc = this.innerArc(innerRadius, outerRadius);
     const outerArc = this.outerArc(outerRadius);
     const positions = this.calculateLabelPositions(outerArc, outerRadius);
-    const centroid = this.centroid(innerRadius, outerRadius);
+    // this is a minimal distance that we want label polyline to extend from pie
+    // till the first time we will change line direction
+    const centroid = this.centroid(outerRadius + 4, outerRadius + 4);
 
     return (
       <Fragment>

--- a/src/PieChart/PieChart.story.tsx
+++ b/src/PieChart/PieChart.story.tsx
@@ -53,9 +53,20 @@ storiesOf('Charts/Pie Chart/Pie', module)
       data={browserData}
     />
   ))
-  .add('Label Overlap', () => (
-    <PieChart width={350} height={250} data={browserData} />
-  ))
+  .add('Label Overlap', () => {
+    const labelsCount = number('Labels count', 32);
+
+    return (
+      <PieChart
+        width={350}
+        height={250}
+        data={[...Array(labelsCount)].map((_, index) => ({
+          key: index + 1,
+          data: 1
+        }))}
+      />
+    );
+  })
   .add('Display All Labels', () => (
     <PieChart
       width={350}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Current label polyline coords calculation algorithm may produce odd results in some cases.

The lines may  have completely wrong direction:

![image](https://user-images.githubusercontent.com/2536916/97173055-a378c180-1798-11eb-8825-4b65d379b544.png)

In other cases the lines have such trajectory, that it is difficult to understand exactly to which section the line points to:

![image](https://user-images.githubusercontent.com/2536916/97173217-df138b80-1798-11eb-9c05-167ab71b7b7d.png)

## What is the new behavior?

In this PR I have added an alternative algorithm for the case, when label position is lower, than pie chart outer radius centroid. So now we have two ways to draw label lines:

![image](https://user-images.githubusercontent.com/2536916/97173506-5b0dd380-1799-11eb-9434-ed4c27068b3e.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Please add `hacktoberfest-accepted` label if it is possible to merge this fix till the end of month :)