### PR TITLE
fix: revert typescript 3.8 "import type" syntax usage to allow support typescript < 3.7

### DIFF
--- a/src/PieChart/PieArcSeries/PieArcLabel.test.tsx
+++ b/src/PieChart/PieArcSeries/PieArcLabel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { PieArcLabel } from './PieArcLabel';
-import type { ArcData } from '../PieChart';
+import { ArcData } from '../PieChart';
 
 const data: ArcData = {
   data: {

--- a/src/PieChart/PieArcSeries/PieArcLabel.tsx
+++ b/src/PieChart/PieArcSeries/PieArcLabel.tsx
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
 import { motion } from 'framer-motion';
 import { arc } from 'd3-shape';
-import type { ArcData } from '../PieChart';
-import type { ChartInternalDataTypes } from '../../common/data/types';
+import { ArcData } from '../PieChart';
+import { ChartInternalDataTypes } from '../../common/data/types';
 import { formatValue } from '../../common/utils/formatting';
 import { findBreakPoint } from './findBreakPoint';
 

--- a/src/PieChart/PieArcSeries/PieArcSeries.tsx
+++ b/src/PieChart/PieArcSeries/PieArcSeries.tsx
@@ -3,7 +3,7 @@ import { max } from 'd3-array';
 import { arc } from 'd3-shape';
 import { CloneElement } from 'rdk';
 import memoize from 'memoize-one';
-import type { ArcData } from '../PieChart';
+import { ArcData } from '../PieChart';
 import { PieArc, PieArcProps } from './PieArc';
 import { PieArcLabel, PieArcLabelProps } from './PieArcLabel';
 import { getColor, ColorSchemeType } from '../../common/color';

--- a/src/PieChart/PieChart.tsx
+++ b/src/PieChart/PieChart.tsx
@@ -1,7 +1,6 @@
 import React, { Component, ReactElement } from 'react';
 import classNames from 'classnames';
-import type { PieArcDatum } from 'd3-shape';
-import { pie } from 'd3-shape';
+import { pie, PieArcDatum } from 'd3-shape';
 import memoize from 'memoize-one';
 import { CloneElement } from 'rdk';
 import {
@@ -9,7 +8,7 @@ import {
   ChartContainer,
   ChartContainerChildProps
 } from '../common/containers/ChartContainer';
-import type { ChartShallowDataShape } from '../common/data';
+import { ChartShallowDataShape } from '../common/data';
 import { PieArcSeries, PieArcSeriesProps } from './PieArcSeries';
 
 export type ArcData = PieArcDatum<ChartShallowDataShape>;

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
@@ -1,7 +1,6 @@
 import React, { Component, ReactElement } from 'react';
 import { arc } from 'd3-shape';
-import type { ArcData, PieArcProps } from '../../PieChart';
-import { PieArc } from '../../PieChart';
+import { PieArc, ArcData, PieArcProps } from '../../PieChart';
 import { ChartShallowDataShape } from '../../common/data';
 import { ChartTooltip, ChartTooltipProps } from '../../common/Tooltip';
 


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I've introduced `import type` syntax in #10 which is supported in typescript 3.8+. This PR reverts that change to support users with older typescript version

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

