### PR TITLE
Better arcs

### DIFF
--- a/docs/charts/RadialGauge.story.mdx
+++ b/docs/charts/RadialGauge.story.mdx
@@ -1,5 +1,13 @@
 import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
-import { RadialGauge, RadialGaugeSeries, RadialGaugeArc, RadialGaugeLabel, RadialGaugeValueLabel } from '../../src';
+import {
+  RadialGauge,
+  RadialGaugeSeries,
+  RadialGaugeArc,
+  RadialGaugeLabel,
+  RadialGaugeValueLabel,
+  StackedRadialGaugeSeries,
+  StackedRadialGaugeLabel
+} from '../../src';
 
 <Meta title="Docs/Chart Types/Radial Gauge" />
 
@@ -40,11 +48,17 @@ distribute the values across them.
 ### [RadialGaugeSeries](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx)
 <ArgsTable of={RadialGaugeSeries} />
 
+### [StackedRadialGaugeSeries](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/StackedRadialGaugeSeries.tsx)
+<ArgsTable of={StackedRadialGaugeSeries} />
+
 ### [RadialGaugeArc](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx)
 <ArgsTable of={RadialGaugeArc} />
 
 ### [RadialGaugeLabel](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/RadialGaugeSeries/RadialGaugeLabel.tsx)
 <ArgsTable of={RadialGaugeLabel} />
+
+### [StackedRadialGaugeLabel](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeLabel.tsx)
+<ArgsTable of={StackedRadialGaugeLabel} />
 
 ### [RadialGaugeValueLabel](https://github.com/reaviz/reaviz/blob/master/src/RadialGauge/RadialGaugeSeries/RadialGaugeValueLabel.tsx)
 <ArgsTable of={RadialGaugeValueLabel} />

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
       ".(ts|tsx)": "ts-jest"
     },
     "testMatch": [
-      "<rootDir>/src/**/?(*.)(spec|test).ts?(x)"
+      "<rootDir>/src/**/*(*.)@(spec|test).[t]s?(x)"
     ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"

--- a/src/PieChart/PieArcSeries/PieArc.tsx
+++ b/src/PieChart/PieArcSeries/PieArc.tsx
@@ -12,15 +12,58 @@ export interface PieArcMouseEvent {
 }
 
 export interface PieArcProps {
+  /**
+   * The arc generator function returning an arc path
+   * @param data
+   */
   arc?: (data: ArcData) => string | null;
+
+  /**
+   * Data is the datum passed to the arc generator function
+   */
   data?: ArcData;
+
+  /**
+   * Color
+   */
   color?: string;
+
+  /**
+   * Animate
+   */
   animated?: boolean;
+
+  /**
+   * Tooltip component
+   */
   tooltip?: ReactElement<ChartTooltipProps, typeof ChartTooltip> | null;
+
+  /**
+   * The cursor type used when hovering
+   */
   cursor?: string;
+
+  /**
+   * Disable the arc
+   */
   disabled?: boolean;
+
+  /**
+   * OnClick event handler
+   * @param e Click event
+   */
   onClick?: (e: PieArcMouseEvent) => void;
+
+  /**
+   * MouseEnter event handler
+   * @param e MouseEnter event
+   */
   onMouseEnter?: (e: PieArcMouseEvent) => void;
+
+  /**
+   * MouseLeave event handler
+   * @param e MouseLeave event
+   */
   onMouseLeave?: (e: PieArcMouseEvent) => void;
 }
 

--- a/src/PieChart/PieArcSeries/PieArc.tsx
+++ b/src/PieChart/PieArcSeries/PieArc.tsx
@@ -12,8 +12,8 @@ export interface PieArcMouseEvent {
 }
 
 export interface PieArcProps {
+  arc?: (data: ArcData) => string | null;
   data?: ArcData;
-  innerArc?: (data: ArcData) => string | null;
   color?: string;
   animated?: boolean;
   tooltip?: ReactElement<ChartTooltipProps, typeof ChartTooltip> | null;
@@ -27,7 +27,7 @@ export interface PieArcProps {
 export const PieArc: FC<PieArcProps> = ({
   color,
   data,
-  innerArc,
+  arc,
   cursor = 'initial',
   animated = true,
   disabled = false,
@@ -37,7 +37,7 @@ export const PieArc: FC<PieArcProps> = ({
   tooltip = <ChartTooltip />
 }) => {
   const arcRef = useRef<SVGPathElement | null>(null);
-  const { transition, d } = useInterpolate({ animated, innerArc, data });
+  const { transition, d } = useInterpolate({ animated, arc, data });
   const [active, setActive] = useState<boolean>(false);
   const fill = useMemo(() => (active ? chroma(color).brighten(0.5) : color), [
     color,

--- a/src/PieChart/PieArcSeries/PieArcLabel.tsx
+++ b/src/PieChart/PieArcSeries/PieArcLabel.tsx
@@ -7,20 +7,69 @@ import { formatValue } from '../../common/utils/formatting';
 import { findBreakPoint } from './findBreakPoint';
 
 export interface PieArcLabelProps {
+  /**
+   * Data set by the parent component
+   */
   data: ArcData;
+
+  /**
+   * A function returning the centroid of the corresponding `PieArc`
+   * @param d PieArcDatum
+   */
   centroid: (d: ArcData) => [number, number];
+
+  /**
+   * A Formatting function for the label value
+   * @param v The label value
+   */
   format?: (
     // have added any because not sure whether this change won't be breaking
     v: any & ArcData['data'] & { textAnchor: 'start' | 'end' }
   ) => React.ReactNode;
+
+  /**
+   * FontFill color
+   */
   fontFill: string;
+
+  /**
+   * FontSize
+   */
   fontSize: number;
-  outerRadius: number;
+
+  /**
+   * FontFamily
+   */
   fontFamily: string;
+
+  /**
+   * Line stroke of the label connector
+   */
   lineStroke: string;
+
+  /**
+   * Outer radius of the corresponding `PieArc`
+   */
+  outerRadius: number;
+
+  /**
+   * y Padding of the label
+   */
   padding: string;
+
+  /**
+   * The label position set by the parent component
+   */
   position: [number, number];
+
+  /**
+   * Width of the label
+   */
   width?: number;
+
+  /**
+   * Height of the label
+   */
   height?: number;
 }
 

--- a/src/PieChart/PieArcSeries/PieArcSeries.tsx
+++ b/src/PieChart/PieArcSeries/PieArcSeries.tsx
@@ -9,22 +9,84 @@ import { PieArcLabel, PieArcLabelProps } from './PieArcLabel';
 import { getColor, ColorSchemeType } from '../../common/color';
 
 export interface PieArcSeriesProps {
+  /**
+   * Animated set by the `PieArc` components.
+   */
   animated: boolean;
+
+  /**
+   * Outer radius set by the parent component.
+   */
   outerRadius: number;
+
+  /**
+   * Inner radius set by the parent component.
+   */
   innerRadius: number;
+
+  /**
+   * Pad Angle between adjacent arcs, see https://github.com/d3/d3-shape#arc_padAngle
+   */
   padAngle: number;
+
+  /**
+   * Pad Radius between adjacent arcs, see https://github.com/d3/d3-shape#arc_padRadius
+   */
   padRadius: number;
+
+  /**
+   * Corner Radius of the arcs, see https://github.com/d3/d3-shape#arc_cornerRadius
+   */
   cornerRadius: number;
+
+  /**
+   * Data set by the parent component.
+   */
   data: ArcData[];
+
+  /**
+   * Width of the arc
+   */
   arcWidth: number;
 
+  /**
+   * Doughnut, render as a donut shape
+   */
   doughnut: boolean;
+
+  /**
+   * Explode: OuterRadius will be adjusted by the data property
+   */
   explode: boolean;
+
+  /**
+   * Display all labels shows labels even if there is little space
+   */
   displayAllLabels: boolean;
+
+  /**
+   * Label component
+   */
   label?: ReactElement<PieArcLabelProps, typeof PieArcLabel> | null;
+
+  /**
+   * Arc Component
+   */
   arc: ReactElement<PieArcProps, typeof PieArc>;
+
+  /**
+   * Color scheme
+   */
   colorScheme: ColorSchemeType;
+
+  /**
+   * Height set by the parent component
+   */
   height: number;
+
+  /**
+   * Width set by the parent component
+   */
   width: number;
 }
 

--- a/src/PieChart/PieArcSeries/useInterpolate.ts
+++ b/src/PieChart/PieArcSeries/useInterpolate.ts
@@ -3,7 +3,7 @@ import { DEFAULT_TRANSITION } from '../../common/Motion';
 import { useMotionValue, useSpring } from 'framer-motion';
 import { interpolate } from 'd3-interpolate';
 
-export const useInterpolate = ({ data, animated, innerArc }) => {
+export const useInterpolate = ({ data, animated, arc }) => {
   const prevEnter = useRef<any | null>(null);
 
   const exit = useMemo(() => {
@@ -22,8 +22,8 @@ export const useInterpolate = ({ data, animated, innerArc }) => {
       animated
         ? { ...DEFAULT_TRANSITION }
         : {
-            delay: 0
-          },
+          delay: 0
+        },
     [animated]
   );
 
@@ -44,10 +44,10 @@ export const useInterpolate = ({ data, animated, innerArc }) => {
   useEffect(() => {
     const from = previousEnter || prevPath.get();
     const interpolator = interpolate(from, data);
-    const unsub = spring.onChange((v) => d.set(innerArc(interpolator(v))));
+    const unsub = spring.onChange((v) => d.set(arc(interpolator(v))));
     prevPath.set(data);
     return unsub;
-  }, [innerArc, data]);
+  }, [arc, data]);
 
   return {
     d,

--- a/src/PieChart/PieChart.story.tsx
+++ b/src/PieChart/PieChart.story.tsx
@@ -244,6 +244,32 @@ storiesOf('Charts/Pie Chart/Donut', module)
       />
     );
   })
+  .add('Rounded and spaced', () => {
+    const height = number('Height', 250);
+    const width = number('Width', 350);
+    const padAngle = number('Pad Angle', 0.02);
+    const padRadius = number('Pad Radius', 200);
+    const cornerRadius = number('Corner Radius', 4);
+    const color = select('Color Scheme', schemes, 'cybertron');
+    const data = object('Data', categoryData);
+
+    return (
+      <PieChart
+        width={width}
+        height={height}
+        data={data}
+        series={
+          <PieArcSeries
+            cornerRadius={cornerRadius}
+            padAngle={padAngle}
+            padRadius={padRadius}
+            doughnut={true}
+            colorScheme={color}
+          />
+        }
+      />
+    );
+  })
   .add('Labels', () => (
     <PieChart
       width={350}

--- a/src/PieChart/PieChart.tsx
+++ b/src/PieChart/PieChart.tsx
@@ -41,7 +41,7 @@ export const PieChart: FC<PieChartProps> = ({
   height,
   className,
   displayAllLabels = false,
-  data,
+  data = [],
   margins = 10,
   series = <PieArcSeries />
 }) => {

--- a/src/PieChart/PieChart.tsx
+++ b/src/PieChart/PieChart.tsx
@@ -17,7 +17,7 @@ export interface PieChartProps extends ChartProps {
   /**
    * Data the chart will receive to render.
    */
-  data: ChartShallowDataShape[];
+  data?: ChartShallowDataShape[];
 
   /**
    * Whether the chart is disabled.
@@ -32,7 +32,7 @@ export interface PieChartProps extends ChartProps {
   /**
    * The series component that renders the arc components.
    */
-  series: ReactElement<PieArcSeriesProps, typeof PieArcSeries>;
+  series?: ReactElement<PieArcSeriesProps, typeof PieArcSeries>;
 }
 
 export const PieChart: FC<PieChartProps> = ({

--- a/src/PieChart/PieChart.tsx
+++ b/src/PieChart/PieChart.tsx
@@ -1,13 +1,13 @@
-import React, { Component, ReactElement } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import classNames from 'classnames';
-import { pie, PieArcDatum } from 'd3-shape';
-import memoize from 'memoize-one';
+import { PieArcDatum } from 'd3-shape';
+import { pie } from 'd3-shape';
 import { CloneElement } from 'rdk';
 import {
   ChartProps,
   ChartContainer,
   ChartContainerChildProps
-} from '../common/containers/ChartContainer';
+} from '../common/containers';
 import { ChartShallowDataShape } from '../common/data';
 import { PieArcSeries, PieArcSeriesProps } from './PieArcSeries';
 
@@ -35,63 +35,52 @@ export interface PieChartProps extends ChartProps {
   series: ReactElement<PieArcSeriesProps, typeof PieArcSeries>;
 }
 
-export class PieChart extends Component<PieChartProps> {
-  static defaultProps: PieChartProps = {
-    disabled: false,
-    displayAllLabels: false,
-    data: [],
-    margins: 10,
-    series: <PieArcSeries />
-  };
+export const PieChart: FC<PieChartProps> = ({
+  id,
+  width,
+  height,
+  className,
+  displayAllLabels = false,
+  data,
+  margins = 10,
+  series = <PieArcSeries />
+}) => {
+  const getData = useMemo(() => {
+    const pieLayout = pie<
+      void,
+      ChartShallowDataShape
+    >().value((d: ChartShallowDataShape) => Number(d.data));
 
-  getData = memoize(
-    (data: ChartShallowDataShape[], explode: boolean): ArcData[] => {
-      const pieLayout = pie<
-        void,
-        ChartShallowDataShape
-      >().value((d: ChartShallowDataShape) => Number(d.data));
-
-      // Explode sort doesn't work right...
-      if (!explode) {
-        pieLayout.sort(null);
-      }
-
-      return pieLayout(data);
+    // Explode sort doesn't work right...
+    if (!series.props.explode) {
+      pieLayout.sort(null);
     }
+
+    return pieLayout(data);
+  }, [data, series]);
+
+  return (
+    <ChartContainer
+      id={id}
+      width={width}
+      height={height}
+      margins={margins}
+      xAxisVisible={false}
+      yAxisVisible={false}
+      center={true}
+      className={classNames(className)}
+    >
+      {({ chartWidth, chartHeight }: ChartContainerChildProps) => {
+        return (
+          <CloneElement<PieArcSeriesProps>
+            element={series}
+            data={getData}
+            height={chartHeight}
+            width={chartWidth}
+            displayAllLabels={displayAllLabels}
+          />
+        );
+      }}
+    </ChartContainer>
   );
-
-  renderChart(containerProps: ChartContainerChildProps) {
-    const { chartWidth, chartHeight } = containerProps;
-    const { series, displayAllLabels } = this.props;
-    const data = this.getData(this.props.data, this.props.series.props.explode);
-
-    return (
-      <CloneElement<PieArcSeriesProps>
-        element={series}
-        data={data}
-        height={chartHeight}
-        width={chartWidth}
-        displayAllLabels={displayAllLabels}
-      />
-    );
-  }
-
-  render() {
-    const { id, width, height, margins, className } = this.props;
-
-    return (
-      <ChartContainer
-        id={id}
-        width={width}
-        height={height}
-        margins={margins}
-        xAxisVisible={false}
-        yAxisVisible={false}
-        center={true}
-        className={classNames(className)}
-      >
-        {(props) => this.renderChart(props)}
-      </ChartContainer>
-    );
-  }
-}
+};

--- a/src/RadialGauge/RadialGauge.story.tsx
+++ b/src/RadialGauge/RadialGauge.story.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { RadialGauge } from './RadialGauge';
-import { number, object, color, array, text } from '@storybook/addon-knobs';
+import {
+  number,
+  object,
+  color,
+  array,
+  text,
+  boolean
+} from '@storybook/addon-knobs';
 import { categoryData } from '../../demo';
-import { RadialGaugeSeries } from './RadialGaugeSeries';
+import {
+  RadialGaugeArc,
+  RadialGaugeSeries,
+  StackedRadialGaugeLabel,
+  StackedRadialGaugeSeries
+} from './RadialGaugeSeries';
+
 import { max } from 'd3-array';
-import { StackedRadialGaugeSeries } from './RadialGaugeSeries/StackedRadialGaugeSeries';
-import { StackedRadialGaugeLabel } from './RadialGaugeSeries/StackedRadialGaugeLabel';
 
 storiesOf('Charts/Gauge/Radial', module)
   .add('Single', () => {
@@ -14,6 +25,7 @@ storiesOf('Charts/Gauge/Radial', module)
     const endAngle = number('End Angle', Math.PI * 2);
     const minValue = number('Min Value', 0);
     const maxValue = number('Max Value', 100);
+    const arcWidth = number('Arc width', 10);
     const height = number('Height', 300);
     const width = number('Width', 300);
     const colorScheme = color('Color', '#418AD7');
@@ -33,7 +45,40 @@ storiesOf('Charts/Gauge/Radial', module)
         width={width}
         minValue={minValue}
         maxValue={maxValue}
-        series={<RadialGaugeSeries colorScheme={[colorScheme]} />}
+        series={
+          <RadialGaugeSeries arcWidth={arcWidth} colorScheme={[colorScheme]} />
+        }
+      />
+    );
+  })
+  .add('Custom Arc', () => {
+    const arcWidth = number('Arc width', 25);
+    const arcCornerRadius = number('Arc corner radius', 12.5);
+
+    const colorScheme = color('Color', '#38e52c');
+    const animateOuterArc = boolean('Animate background arc', false);
+    const data = object('Data', [
+      {
+        key: 'Austin, TX',
+        data: 24
+      }
+    ]);
+
+    return (
+      <RadialGauge
+        data={data}
+        height={300}
+        width={300}
+        series={
+          <RadialGaugeSeries
+            outerArc={
+              <RadialGaugeArc disabled={true} animated={animateOuterArc} />
+            }
+            innerArc={<RadialGaugeArc cornerRadius={arcCornerRadius} />}
+            arcWidth={arcWidth}
+            colorScheme={[colorScheme]}
+          />
+        }
       />
     );
   })

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
@@ -36,17 +36,17 @@ export interface RadialGaugeArcProps {
   color: any;
 
   /**
-   * Corner Radius set by the `RadialGaugeSeries` components.
+   * Corner Radius of the arcs, see https://github.com/d3/d3-shape#arc_cornerRadius
    */
   cornerRadius?: number;
 
   /**
-   * Pad Angle set by the `RadialGaugeSeries` components.
+   * Pad Angle between adjacent arcs, see https://github.com/d3/d3-shape#arc_padAngle
    */
   padAngle?: number;
 
   /**
-   * Pad Radius set by the `RadialGaugeSeries` components.
+   * Pad Radius between adjacent arcs, see https://github.com/d3/d3-shape#arc_padRadius
    */
   padRadius?: number;
 

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactElement } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { arc } from 'd3-shape';
 import { PieArc, ArcData, PieArcProps } from '../../PieChart';
 import { ChartShallowDataShape } from '../../common/data';
@@ -6,34 +6,49 @@ import { ChartTooltip, ChartTooltipProps } from '../../common/Tooltip';
 
 export interface RadialGaugeArcProps {
   /**
-   * Data set by the `RadialGaugeSeries` component.
+   * Data set by the `RadialGaugeSeries` components.
    */
   data?: ChartShallowDataShape;
 
   /**
-   * Start angle set by the `RadialGaugeSeries` component.
+   * Start angle set by the `RadialGaugeSeries` components.
    */
   startAngle: number;
 
   /**
-   * End angle set by the `RadialGaugeSeries` component.
+   * End angle set by the `RadialGaugeSeries` components.
    */
   endAngle: number;
 
   /**
-   * Outer radius set by the `RadialGaugeSeries` component.
+   * Inner radius set by the `RadialGaugeSeries` components.
+   */
+  innerRadius: number;
+
+  /**
+   * Outer radius set by the `RadialGaugeSeries` components.
    */
   outerRadius: number;
 
   /**
-   * Color set by the `RadialGaugeSeries` component.
+   * Color set by the `RadialGaugeSeries` components.
    */
   color: any;
 
   /**
-   * Width set by the `RadialGaugeSeries` component.
+   * Corner Radius set by the `RadialGaugeSeries` components.
    */
-  width: number;
+  cornerRadius?: number;
+
+  /**
+   * Pad Angle set by the `RadialGaugeSeries` components.
+   */
+  padAngle?: number;
+
+  /**
+   * Pad Radius set by the `RadialGaugeSeries` components.
+   */
+  padRadius?: number;
 
   /**
    * Animation set by the `RadialGaugeSeries` component.
@@ -66,69 +81,53 @@ export interface RadialGaugeArcProps {
   onMouseLeave: (event) => void;
 }
 
-export class RadialGaugeArc extends Component<RadialGaugeArcProps> {
-  static defaultProps: Partial<RadialGaugeArcProps> = {
-    width: 5,
-    color: '#353d44',
-    animated: true,
-    disabled: false,
-    onClick: () => undefined,
-    onMouseEnter: () => undefined,
-    onMouseLeave: () => undefined,
-    tooltip: <ChartTooltip />
+export const RadialGaugeArc: FC<Partial<RadialGaugeArcProps>> = ({
+  data,
+  startAngle,
+  endAngle,
+  innerRadius,
+  outerRadius,
+  cornerRadius = 0,
+  padAngle = 0,
+  padRadius = 0,
+  color = '#353d44',
+  animated = true,
+  disabled = false,
+  onClick = () => undefined,
+  onMouseEnter = () => undefined,
+  onMouseLeave = () => undefined,
+  tooltip = <ChartTooltip />
+}: Partial<RadialGaugeArcProps>) => {
+  /**
+   * This function will generate the arcs
+   * https://github.com/d3/d3-shape#arcs
+   */
+  const arcGenerator = useMemo(() => {
+    return arc<ArcData>()
+      .innerRadius(innerRadius)
+      .outerRadius(outerRadius)
+      .cornerRadius(cornerRadius);
+  }, [innerRadius, outerRadius, cornerRadius, padAngle, padRadius]);
+
+  const arcData: ArcData = {
+    // @ts-ignore Data must be passed
+    data: data || {},
+    startAngle,
+    endAngle,
+    padAngle
   };
 
-  getPaths(): Pick<PieArcProps, 'data' | 'innerArc'> {
-    const { outerRadius, startAngle, endAngle, width, data } = this.props;
-
-    // Calculate the inner rad based on the width
-    // and the outer rad which is height/width / 2
-    const innerRadius = outerRadius - width;
-
-    // Center arcs so inner/outer align nicely
-    const delta = (outerRadius - innerRadius) / 2;
-    const newInnerRad = innerRadius + delta;
-    const newOuterRad = outerRadius + delta;
-
-    // Create the arc fn to pass to the pie arc
-    const innerArc = arc<ArcData>()
-      .innerRadius(newInnerRad)
-      .outerRadius(newOuterRad);
-
-    return {
-      data: {
-        startAngle,
-        endAngle,
-        // @ts-ignore Data must be passed
-        data: data || {}
-      },
-      innerArc
-    };
-  }
-
-  render() {
-    const {
-      color,
-      animated,
-      disabled,
-      tooltip,
-      onClick,
-      onMouseEnter,
-      onMouseLeave
-    } = this.props;
-    const data = this.getPaths();
-
-    return (
-      <PieArc
-        {...data}
-        animated={animated}
-        color={color}
-        disabled={disabled}
-        tooltip={tooltip}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      />
-    );
-  }
-}
+  return (
+    <PieArc
+      arc={arcGenerator}
+      data={arcData}
+      animated={animated}
+      color={color}
+      disabled={disabled}
+      tooltip={tooltip}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    />
+  );
+};

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeLabel.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeLabel.tsx
@@ -3,7 +3,7 @@ import {
   ChartShallowDataShape,
   ChartInternalDataTypes
 } from '../../common/data';
-import { formatValue } from '../../common/utils/formatting';
+import { formatValue } from '../../common/utils';
 import css from './RadialGaugeLabel.module.scss';
 import classNames from 'classnames';
 
@@ -40,10 +40,11 @@ export class RadialGaugeLabel extends PureComponent<RadialGaugeLabelProps> {
 
     return (
       <text
-        dy="1.23em"
         x="0"
         y={offset}
         textAnchor="middle"
+        // This is only valid when placed below the chart
+        alignmentBaseline={'text-after-edge'}
         onClick={(nativeEvent) => onClick({ data, nativeEvent })}
         className={classNames(className, css.valueLabel)}
       >

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
@@ -14,32 +14,37 @@ import {
 
 export interface RadialGaugeSeriesProps {
   /**
-   * Data to render set bby `RadialGauge` component.
+   * Data to render set by `RadialGauge` component.
    */
   data: ChartShallowDataShape[];
 
   /**
-   * D3 scale function set bby `RadialGauge` component.
+   * D3 scale function set by `RadialGauge` component.
    */
   scale: any;
 
   /**
-   * Start angle set bby `RadialGauge` component.
+   * Start angle set by `RadialGauge` component.
    */
   startAngle: number;
 
   /**
-   * Start angle set bby `RadialGauge` component.
+   * Start angle set by `RadialGauge` component.
    */
   endAngle: number;
 
   /**
-   * Width set bby `RadialGauge` component.
+   * The "thickness" of the arcs
+   */
+  arcWidth?: number;
+
+  /**
+   * Width set by `RadialGauge` component.
    */
   width: number;
 
   /**
-   * Height set bby `RadialGauge` component.
+   * Height set by `RadialGauge` component.
    */
   height: number;
 
@@ -87,12 +92,13 @@ export const RadialGaugeSeries: FC<Partial<RadialGaugeSeriesProps>> = ({
   scale,
   startAngle,
   endAngle,
+  arcWidth = 10,
   outerArc = <RadialGaugeArc disabled={true} />,
-  innerArc = <RadialGaugeArc width={10} animated={true} />,
+  innerArc = <RadialGaugeArc animated={true} />,
   label = <RadialGaugeLabel />,
   valueLabel = <RadialGaugeValueLabel />,
   colorScheme = ['#00ECB1'],
-  padding = 10,
+  padding = 20,
   minGaugeWidth = 50,
   ...props
 }: Partial<RadialGaugeSeriesProps>) => {
@@ -135,22 +141,18 @@ export const RadialGaugeSeries: FC<Partial<RadialGaugeSeriesProps>> = ({
   ) {
     const dataEndAngle = scale(point.data as number);
 
-    const baselineLabelHeight = 20;
     const outerRadius =
-      (min([
-        width - padding,
-        height - baselineLabelHeight - padding
-      ]) as number) /
-        2 -
-      10;
+      (min([width - padding * 2, height - padding * 2]) as number) / 2;
 
-    const labelOffset = height / 2 - baselineLabelHeight;
+    const innerRadius = outerRadius - arcWidth;
+
+    const labelOffset = height / 2;
 
     const x = xScale(index % columns);
     const y = yScale(Math.floor(index / columns));
 
     const xOffset = x + (width - padding) / 2;
-    const yOffset = y + (height - baselineLabelHeight) / 2;
+    const yOffset = y + height / 2;
 
     return (
       <g
@@ -158,10 +160,16 @@ export const RadialGaugeSeries: FC<Partial<RadialGaugeSeriesProps>> = ({
         key={point.key.toLocaleString()}
       >
         {outerArc &&
-          cloneElement(outerArc, { outerRadius, startAngle, endAngle })}
+          cloneElement(outerArc, {
+            outerRadius,
+            innerRadius,
+            startAngle,
+            endAngle
+          })}
         {innerArc &&
           cloneElement(innerArc, {
             outerRadius,
+            innerRadius,
             startAngle,
             endAngle: dataEndAngle,
             data: point,

--- a/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeSeries.tsx
@@ -23,22 +23,22 @@ export interface StackedRadialGaugeSeriesProps {
   scale: any;
 
   /**
-   * Start angle set bby `RadialGauge` component.
+   * Start angle set by `RadialGauge` component.
    */
   startAngle: number;
 
   /**
-   * Start angle set bby `RadialGauge` component.
+   * Start angle set by `RadialGauge` component.
    */
   endAngle: number;
 
   /**
-   * Width set bby `RadialGauge` component.
+   * Width set by `RadialGauge` component.
    */
   width: number;
 
   /**
-   * Height set bby `RadialGauge` component.
+   * Height set by `RadialGauge` component.
    */
   height: number;
 
@@ -76,9 +76,9 @@ export interface StackedRadialGaugeSeriesProps {
   arcPadding: number;
 }
 
-export const StackedRadialGaugeSeries: FC<Partial<
-  StackedRadialGaugeSeriesProps
->> = ({
+export const StackedRadialGaugeSeries: FC<
+  Partial<StackedRadialGaugeSeriesProps>
+> = ({
   data,
   width,
   height,
@@ -107,19 +107,22 @@ export const StackedRadialGaugeSeries: FC<Partial<
   ) {
     const dataEndAngle = scale(point.data as number);
 
+    const outerRadius = rAxis(index);
+    const innerRadius = outerRadius - rAxis.bandwidth();
+
     return (
       <g key={point.key.toLocaleString()}>
         {outerArc &&
           cloneElement(outerArc, {
-            outerRadius: rAxis(index),
-            width: rAxis.bandwidth(),
+            outerRadius,
+            innerRadius,
             startAngle,
             endAngle
           })}
         {innerArc &&
           cloneElement(innerArc, {
-            outerRadius: rAxis(index),
-            width: rAxis.bandwidth(),
+            outerRadius,
+            innerRadius,
             startAngle,
             endAngle: dataEndAngle,
             data: point,

--- a/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisTick.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisTick.tsx
@@ -2,11 +2,11 @@ import React, { Component, ReactElement } from 'react';
 import {
   RadialAxisTickLineProps,
   RadialAxisTickLine
-} from './RadialAxisTickLine';
+} from '../RadialAxisTickSeries';
 import {
   RadialAxisTickLabelProps,
   RadialAxisTickLabel
-} from './RadialAxisTickLabel';
+} from '../RadialAxisTickSeries';
 import { CloneElement } from 'rdk';
 
 export interface RadialAxisTickProps {


### PR DESCRIPTION
Adding padAngle, padRadius and cornerRadius to the Arcs to use the full potential of the d3 arc generator
renaming the innerArc prop on PieArcProps as it is misleading (breaking change)
Add new story to show the usage
PieChart to FC

**Do not merge**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Corner radius
![image](https://user-images.githubusercontent.com/1744875/99888530-d904b380-2c4d-11eb-82e9-4dd0dfe138ec.png)

padAngle + padRadius + corner radius

![image](https://user-images.githubusercontent.com/1744875/99888545-f043a100-2c4d-11eb-9a02-0de2d5441a56.png)


Full Arc features: https://github.com/d3/d3-shape#arcs

## Does this PR introduce a breaking change?
```
[x] Yes possibly
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This is only a discussion right now, but naming the arc function `innerArc` is just bad

## Other information
