### PR TITLE
Fix CalendarHeatmap series prop not passed into Heatmap

### DIFF
--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -47,11 +47,15 @@ const xAxisLabelFormat = (start: Date) => (weeks: number) =>
 
 export const CalendarHeatmap: FC<Partial<CalendarHeatmapProps>> = ({
   view,
-  series,
   data,
   ...rest
 }) => {
-  const { data: domainData, yDomain, xDomain, start } = useMemo(() => buildDataScales(data, view), [data, view]);
+  const {
+    data: domainData,
+    yDomain,
+    xDomain,
+    start
+  } = useMemo(() => buildDataScales(data, view), [data, view]);
 
   // For month, only pass 1 tick value
   const xTickValues = view === 'year' ? undefined : [1];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`<CalendarHeatmap />` `series` prop is not passed into `<Heatmap />`, including the one from defaultProps, custom element does not render correctly, see the tooltip of storybook:

<img width="730" alt="Screen Shot 2022-09-21 at 22 11 19" src="https://user-images.githubusercontent.com/1288689/191528206-7595394b-a1a2-4daf-8dbb-71134263bc34.png">

Storybook: https://reaviz.io/?path=/story/charts-heatmap-calendar--year-calendar

## What is the new behavior?

`series` is passing through rest props, the tooltip is showing correctly:

<img width="735" alt="Screen Shot 2022-09-21 at 22 06 05" src="https://user-images.githubusercontent.com/1288689/191528358-3d48a55a-f266-4cf2-94fe-8763f3a20e75.png">

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
