### PR TITLE
Add natural-earth projection to Map visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 13.1.14 - 11/08/22
+- [improvement] add ability to pass natural-earth projection to map #90
+
 # 13.1.13 - 10/14/22
 - [fix] Disabled based on aggregated data #93
 - [fix] fix storybook mdxjs failing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaviz",
-  "version": "13.1.13",
+  "version": "13.1.14",
   "description": "Data Visualization using React",
   "scripts": {
     "start": "start-storybook -p 9010 -s public",

--- a/src/Map/Map.story.tsx
+++ b/src/Map/Map.story.tsx
@@ -18,6 +18,10 @@ export default {
 
 export const Simple = () => <Map data={worldData} height={350} width={500} />;
 
+export const NaturalEarthProjection = () => (
+  <Map data={worldData} height={350} width={500} projection="natural-earth" />
+);
+
 export const Autosize = () => (
   <div style={{ width: '50vw', height: '50vh', border: 'solid 1px red' }}>
     <Map data={worldData} />

--- a/src/Map/Map.tsx
+++ b/src/Map/Map.tsx
@@ -1,5 +1,12 @@
 import React, { Fragment, ReactElement, FC, useCallback } from 'react';
-import { geoMercator, geoPath, GeoProjection, GeoPath } from 'd3-geo';
+import {
+  geoNaturalEarth1,
+  geoPath,
+  GeoProjection,
+  GeoPath,
+  geoMercator,
+  geoGraticule
+} from 'd3-geo';
 import {
   ChartProps,
   ChartContainer,
@@ -15,6 +22,7 @@ interface MapProps extends ChartProps {
   markers?: MarkerElement[];
   data: any;
   fill?: string;
+  projection?: 'mercator' | 'natural-earth';
 }
 
 export const Map: FC<MapProps> = ({
@@ -26,12 +34,21 @@ export const Map: FC<MapProps> = ({
   containerClassName,
   markers,
   data,
-  fill
+  fill,
+  projection = 'mercator'
 }) => {
   const getProjection = useCallback(
-    ({ chartWidth, chartHeight }: ChartContainerChildProps) =>
-      geoMercator().fitSize([chartWidth, chartHeight], data).center([0, 35]),
-    [data]
+    ({ chartWidth, chartHeight }: ChartContainerChildProps) => {
+      if (projection === 'natural-earth') {
+        return geoNaturalEarth1()
+          .fitSize([chartWidth, chartHeight], data)
+          .center([0, 0]);
+      }
+      return geoMercator()
+        .fitSize([chartWidth, chartHeight], data)
+        .center([0, 35]);
+    },
+    [data, projection]
   );
 
   const renderMarker = useCallback(
@@ -75,8 +92,8 @@ export const Map: FC<MapProps> = ({
         return null;
       }
 
-      const projection = getProjection(containerProps);
-      const path = geoPath().projection(projection);
+      const geoProjection = getProjection(containerProps);
+      const path = geoPath().projection(geoProjection);
 
       return (
         <motion.g
@@ -93,7 +110,7 @@ export const Map: FC<MapProps> = ({
           {markers &&
             markers.map((marker, index) => (
               <Fragment key={`marker-${index}`}>
-                {renderMarker(marker, index, projection)}
+                {renderMarker(marker, index, geoProjection)}
               </Fragment>
             ))}
         </motion.g>

--- a/src/Map/Map.tsx
+++ b/src/Map/Map.tsx
@@ -4,8 +4,7 @@ import {
   geoPath,
   GeoProjection,
   GeoPath,
-  geoMercator,
-  geoGraticule
+  geoMercator
 } from 'd3-geo';
 import {
   ChartProps,
@@ -22,6 +21,9 @@ interface MapProps extends ChartProps {
   markers?: MarkerElement[];
   data: any;
   fill?: string;
+  /**
+   * Determines how the map transforms spherical geometry to planar geometry
+   */
   projection?: 'mercator' | 'natural-earth';
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #90 


## What is the new behavior?

- Adds [`geoNaturalEarth` projection](https://github.com/d3/d3-geo#geoNaturalEarth1) from `d3-geo` to the `Map` component that can be used by passing `projection="natural-earth"` prop into `Map`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**Docs Update**
![Screen Shot 2022-11-08 at 6 42 38 PM](https://user-images.githubusercontent.com/4616233/200700066-03f16162-76f6-404e-84ae-86858a0d9058.png)


**Storybook Story**
![Screen Shot 2022-11-08 at 6 27 02 PM](https://user-images.githubusercontent.com/4616233/200698512-9a7ae059-78b7-44ad-9cde-6e7321f2bd48.png)
