### PR TITLE
fix disabled brush crashing when clicking on bar

### DIFF
--- a/src/common/Brush/Brush.tsx
+++ b/src/common/Brush/Brush.tsx
@@ -211,7 +211,9 @@ export class Brush extends PureComponent<BrushProps, BrushState> {
           }}
         >
           {children}
-          {!disabled && (
+          {disabled ? (
+            <rect ref={(ref) => (this.ref = ref)} />
+          ) : (
             <Fragment>
               <rect
                 ref={(ref) => (this.ref = ref)}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Disabled brush (ie, if the histogram chart only has 1 bar) and user clicks on the bar and drags, it will crash

Issue Number: N/A


## What is the new behavior?
Underlying problem is that `ref` is undefined when disabled, so I'm adding a <rect /> with a ref to fix the issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
