### PR TITLE
ignore onMoveStart and onMove if brush is disabled

### DIFF
--- a/src/common/Brush/Brush.tsx
+++ b/src/common/Brush/Brush.tsx
@@ -133,34 +133,42 @@ export class Brush extends PureComponent<BrushProps, BrushState> {
   }
 
   onMoveStart(event) {
-    const positions = this.getPositionsForPanEvent(event.nativeEvent);
+    const { disabled } = this.props;
 
-    this.setState({
-      isSlicing: true,
-      initial: positions.x
-    });
+    if (!disabled) {
+      const positions = this.getPositionsForPanEvent(event.nativeEvent);
+
+      this.setState({
+        isSlicing: true,
+        initial: positions.x
+      });
+    }
   }
 
   onMove(event) {
-    this.setState((prev) => {
-      const { onBrushChange } = this.props;
+    const { disabled } = this.props;
 
-      // Use setState callback so we can get the true previous value
-      // rather than the bulk updated value react will trigger
-      const { start, end } = this.getStartEnd(event.nativeEvent, prev);
+    if (!disabled) {
+      this.setState((prev) => {
+        const { onBrushChange } = this.props;
 
-      if (onBrushChange) {
-        onBrushChange({
+        // Use setState callback so we can get the true previous value
+        // rather than the bulk updated value react will trigger
+        const { start, end } = this.getStartEnd(event.nativeEvent, prev);
+
+        if (onBrushChange) {
+          onBrushChange({
+            start,
+            end
+          });
+        }
+
+        return {
           start,
           end
-        });
-      }
-
-      return {
-        start,
-        end
-      };
-    });
+        };
+      });
+    }
   }
 
   onMoveEnd() {
@@ -211,9 +219,7 @@ export class Brush extends PureComponent<BrushProps, BrushState> {
           }}
         >
           {children}
-          {disabled ? (
-            <rect ref={(ref) => (this.ref = ref)} />
-          ) : (
+          {!disabled && (
             <Fragment>
               <rect
                 ref={(ref) => (this.ref = ref)}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Previously, even though I added a ref to an element, it would still cause the domain to update despite the brush being disabled.

Issue Number: N/A


## What is the new behavior?
onMoveStart and onMove is ignored so domain will not change

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
