### PR TITLE
Avoid skip first index on scatter plot grid rendering

### DIFF
--- a/src/common/Gridline/GridlineSeries.tsx
+++ b/src/common/Gridline/GridlineSeries.tsx
@@ -66,24 +66,6 @@ export const GridlineSeries: FC<Partial<GridlineSeriesProps>> = ({
   const shouldRenderX = (direction: 'all' | 'x' | 'y') =>
     direction === 'all' || direction === 'x';
 
-  const getSkipIndex = useCallback(
-    (direction: 'x' | 'y') => {
-      if (
-        (direction === 'x' &&
-          yAxis.axisLine !== null &&
-          yAxis.position === 'start') ||
-        (direction === 'y' &&
-          xAxis.axisLine !== null &&
-          xAxis.position === 'end')
-      ) {
-        return 0;
-      }
-
-      return null;
-    },
-    [xAxis, yAxis]
-  );
-
   const { yAxisGrid, xAxisGrid } = useMemo(() => {
     return {
       yAxisGrid: getTicks(
@@ -111,25 +93,21 @@ export const GridlineSeries: FC<Partial<GridlineSeriesProps>> = ({
       direction: 'x' | 'y',
       type: 'line' | 'stripe'
     ) => {
-      const skipIdx = getSkipIndex(direction);
-
       return grid.map((point, index) => (
         <Fragment key={`${type}-${direction}-${index}`}>
-          {index !== skipIdx && (
-            <CloneElement<GridlineProps | GridStripeProps>
-              element={element}
-              index={index}
-              scale={scale}
-              data={point}
-              height={height}
-              width={width}
-              direction={direction}
-            />
-          )}
+          <CloneElement<GridlineProps | GridStripeProps>
+            element={element}
+            index={index}
+            scale={scale}
+            data={point}
+            height={height}
+            width={width}
+            direction={direction}
+          />
         </Fragment>
       ));
     },
-    [getSkipIndex, height, width]
+    [height, width]
   );
 
   const renderSeries = useCallback(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Scatter Plot Grid Lines missing stripe

Issue Number: [102](https://github.com/reaviz/reaviz/issues/102)


## What is the new behavior?
Avoid skipping first stripe for Scatter Plot Grid Lines


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<img width="805" alt="Screenshot 2022-12-27 at 10 36 34" src="https://user-images.githubusercontent.com/1290843/209639591-e23d582f-98f5-4f39-83d8-409815b54b6c.png">
<img width="770" alt="Screenshot 2022-12-27 at 10 36 41" src="https://user-images.githubusercontent.com/1290843/209639594-e2ca0b7a-8128-495a-bcae-6aaaea09fad3.png">

@amcdnl if you remember why this skip functionality was added - let me know
