### PR TITLE
Barlist: support for percentage values

### DIFF
--- a/src/BarList/BarList.story.tsx
+++ b/src/BarList/BarList.story.tsx
@@ -75,10 +75,17 @@ export const Events = () => (
   </>
 );
 
-export const Format = () => (
+export const PercentageFormat = () => (
   <>
     <style>
       {`
+        .bar {
+          border-radius: 5px;
+        }
+        .outer {
+          background: rgba(0, 0, 0, .2);
+          border-radius: 5px;
+        }
         .value {
           width: 40px;
         }
@@ -90,7 +97,7 @@ export const Format = () => (
         { key: 'Vulnerability Patch', data: 50 },
         { key: 'Critical Failure', data: 25 },
         { key: 'Physical Intrusion', data: 5 },
-        { key: 'Phishing Attempts', data: 100 }
+        { key: 'Phishing Attempts', data: 85 }
       ]}
       series={
         <BarListSeries
@@ -98,8 +105,11 @@ export const Format = () => (
           onItemClick={(d) => alert(`Clicked ${d.key}`)}
           valuePosition="end"
           valueClassName="value"
+          barClassName="bar"
+          outerBarClassName="outer"
         />
       }
+      type='percent'
     />
   </>
 );

--- a/src/BarList/BarList.tsx
+++ b/src/BarList/BarList.tsx
@@ -36,6 +36,12 @@ export interface BarListProps {
    * Series to render.
    */
   series?: ReactElement<BarListSeriesProps, typeof BarList>;
+
+  /**
+   * Whether the values are percentages or absolute values.
+   * In the latter case, the chart would be relative
+   */
+  type?: 'percent' | 'count'
 }
 
 export const BarList: FC<BarListProps> = ({
@@ -44,12 +50,13 @@ export const BarList: FC<BarListProps> = ({
   className,
   sortDirection,
   style,
-  series
+  series,
+  type
 }) => {
   const curId = useId(id);
 
   const mashedData = useMemo(() => {
-    const maxVal = max(data, (d) => d.data);
+    const maxVal = type === 'count' ? max(data, (d) => d.data) : 100;
     const domainVal = maxVal == 0 ? [0] : [0, maxVal];
     const groupScale = scaleLinear().domain(domainVal).rangeRound([0, 100]);
 
@@ -100,5 +107,6 @@ export const BarList: FC<BarListProps> = ({
 BarList.defaultProps = {
   data: [],
   sortDirection: 'desc',
-  series: <BarListSeries />
+  series: <BarListSeries />,
+  type: 'count'
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
This PR adds support for percentage values in the BarList component. Earlier all the bars were relative so even if the inputs were percentages and the max input was less than 100, it would still show a full bar.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Incorrectly renders percentage value bars.
<img width="475" alt="Screenshot 2023-07-08 at 10 31 01 AM" src="https://github.com/reaviz/reaviz/assets/33908100/c6a933b7-f339-45e7-a1b0-0023fdbaff3b">

Issue Number: N/A


## What is the new behavior?
Correctly renders percentage value bars.
<img width="475" alt="Screenshot 2023-07-08 at 10 30 48 AM" src="https://github.com/reaviz/reaviz/assets/33908100/e0269ec8-605f-41a4-b122-a1c94fbcad4d">



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
