### PR TITLE
Calculate TreeMapLabel width based on nowrap value

### DIFF
--- a/src/TreeMap/TreeMapLabel.tsx
+++ b/src/TreeMap/TreeMapLabel.tsx
@@ -50,7 +50,6 @@ export const TreeMapLabel: FC<Partial<TreeMapLabelProps>> = ({
 }) => {
   const key = data.data.key;
   const width = data.x1 - data.x0;
-  const size = calculateDimensions(key, fontFamily, fontSize);
   const text = wrapText({
     key,
     fontFamily,
@@ -61,6 +60,7 @@ export const TreeMapLabel: FC<Partial<TreeMapLabelProps>> = ({
     width,
     height: data.y1 - data.y0
   });
+  const size = calculateDimensions(wrap ? key : text, fontFamily, fontSize);
 
   const offsetX =
     placement === 'start'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
Calculate label width based on nowrap value.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the user sets nowrap to false, the width is calculated based on the whole text instead of just what will be presented on the screen. This causes the text to display outside of the box when placement is set to middle

Issue Number: N/A


## What is the new behavior?
Center text when placement is set to middle and nowrap set to false

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
<img width="217" alt="Screenshot 2023-07-11 at 5 20 34 PM" src="https://github.com/reaviz/reaviz/assets/97488700/77e8bb93-5e35-4ca6-92f1-a0788a0b0183">
<img width="1518" alt="Screenshot 2023-07-11 at 5 18 57 PM" src="https://github.com/reaviz/reaviz/assets/97488700/a2779e04-1736-4a0e-a3b1-439872e32413">

**Solution:**
<img width="476" alt="Screenshot 2023-07-11 at 5 22 12 PM" src="https://github.com/reaviz/reaviz/assets/97488700/6c5f5da9-035b-4068-b121-108a3be77134">


