### PR TITLE
Sankey: labels should fit within the total width

### DIFF
--- a/src/Sankey/Sankey.story.tsx
+++ b/src/Sankey/Sankey.story.tsx
@@ -46,11 +46,12 @@ export const Simple = () => (
     height={300}
     width={550}
     nodeWidth={5}
+    labelPosition="outside"
     nodes={simpleSankeyNodes.map((node, i) => (
       <SankeyNode
         key={`node-${i}`}
         {...node}
-        label={<SankeyLabel position="outside" />}
+        label={<SankeyLabel />}
         onClick={() => onNodeClick(node.title)}
       />
     ))}
@@ -58,6 +59,76 @@ export const Simple = () => (
       <SankeyLink key={`link-${i}`} {...link} />
     ))}
   />
+);
+
+export const LabelsInsideContainer = () => (
+  <div style={{ border: 'solid 1px red' }}>
+    <Sankey
+      height={300}
+      width={550}
+      colorScheme="Spectral"
+      labelPosition="outside"
+      labelPaddingPercent={0.1}
+      nodes={simpleSankeyNodes.map((node, i) => (
+        <SankeyNode
+          key={`node-${i}`}
+          {...node}
+          label={<SankeyLabel ellipsis='none' />}
+          onClick={() => onNodeClick(node.title)}
+        />
+      ))}
+      links={simpleSankeyLinks.map((link, i) => (
+        <SankeyLink key={`link-${i}`} {...link} />
+      ))}
+  />
+  </div>
+);
+
+export const LabelsOutsideContainer = () => (
+  <div style={{ border: 'solid 1px red' }}>
+    <Sankey
+      height={300}
+      width={550}
+      colorScheme="Spectral"
+      labelPosition="outside"
+      labelPaddingPercent={0}
+      nodes={simpleSankeyNodes.map((node, i) => (
+        <SankeyNode
+          key={`node-${i}`}
+          {...node}
+          label={<SankeyLabel ellipsis='none' />}
+          onClick={() => onNodeClick(node.title)}
+        />
+      ))}
+      links={simpleSankeyLinks.map((link, i) => (
+        <SankeyLink key={`link-${i}`} {...link} />
+      ))}
+  />
+  </div>
+);
+
+export const FitLongLabels = () => (
+  <div style={{ border: 'solid 1px red' }}>
+    <Sankey
+      height={300}
+      width={550}
+      colorScheme="Spectral"
+      labelPosition="outside"
+      labelPaddingPercent={0.1}
+      nodes={simpleSankeyNodes.map((node, i) => (
+        <SankeyNode
+          key={`node-${i}`}
+          {...node}
+          title={node?.title.repeat(5)}
+          label={<SankeyLabel ellipsis='auto' />}
+          onClick={() => onNodeClick(node.title)}
+        />
+      ))}
+      links={simpleSankeyLinks.map((link, i) => (
+        <SankeyLink key={`link-${i}`} {...link} />
+      ))}
+  />
+  </div>
 );
 
 export const Filtering = () => <DemoStory />;

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -12,7 +12,7 @@ import { ChartInternalDataTypes } from '../../common/data';
 import { CloneElement } from 'rdk';
 import { formatValue } from '../../common/utils/formatting';
 import { Tooltip, TooltipProps } from 'reablocks';
-import { SankeyLabel, SankeyLabelProps } from '../SankeyLabel';
+import { SankeyLabel, SankeyLabelPosition, SankeyLabelProps } from '../SankeyLabel';
 import { SankeyNodeExtra, DEFAULT_COLOR } from '../utils';
 import css from './SankeyNode.module.css';
 import { useHoverIntent } from '../../common/utils/useHoverIntent';
@@ -64,6 +64,18 @@ export interface SankeyNodeProps extends SankeyNodeExtra {
   label: ReactElement<SankeyLabelProps, typeof SankeyLabel>;
 
   /**
+   * Label position. Set internally by `Sankey`.
+   */
+  labelPosition?: SankeyLabelPosition;
+
+  /**
+   * Percentage of total width occupied by labels on 
+   * either side of the graph inside the container.
+   * Set internally by `Sankey`.
+   */
+  labelPadding?: number;
+
+  /**
    * Opacity callback for the node.
    */
   opacity: (active: boolean, disabled: boolean) => number;
@@ -103,6 +115,8 @@ export const SankeyNode: FC<Partial<SankeyNodeProps>> = ({
   active,
   chartWidth,
   label,
+  labelPosition,
+  labelPadding,
   tooltip,
   title,
   value,
@@ -207,6 +221,8 @@ export const SankeyNode: FC<Partial<SankeyNodeProps>> = ({
           chartWidth={chartWidth}
           nodeWidth={nodeWidth}
           node={node}
+          position={labelPosition}
+          labelPadding={labelPadding}
         />
       )}
       {!tooltip?.props?.disabled && (


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The complete width was occupied by just the charts and the labels would always be outside the specified chart area. Only workaround for this was to use another parent div with some padding when using this component as a child component.

<img width="606" alt="Screenshot 2023-07-11 at 6 22 58 PM" src="https://github.com/reaviz/reaviz/assets/33908100/d5e5335f-3eec-4991-9e13-7eb201e14042">


Issue Number: N/A


## What is the new behavior?

- Labels can be restricted to be within the complete chart area itself
<img width="606" alt="Screenshot 2023-07-11 at 6 25 16 PM" src="https://github.com/reaviz/reaviz/assets/33908100/fa915b53-1010-40dc-8139-9b4d5f0b0828">

- Also added support for ellipsizing long labels
<img width="606" alt="Screenshot 2023-07-11 at 6 25 52 PM" src="https://github.com/reaviz/reaviz/assets/33908100/80e9a8b1-dd8f-45b7-b8d3-8f70885032c7">



## Does this PR introduce a breaking change?
```
[x] Yes
[] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Not exactly a breaking change but the `labelPosition` state has been lifted as it is used while computing the chart area so by default all the labels would be 'inside' even if a 'outside' value was specified in the `SankeyLabel` component.

## Other information
