### PR TITLE
TreepMapLabel: Update nowrap label width

### DIFF
--- a/src/TreeMap/TreeMapLabel.tsx
+++ b/src/TreeMap/TreeMapLabel.tsx
@@ -60,7 +60,11 @@ export const TreeMapLabel: FC<Partial<TreeMapLabelProps>> = ({
     width,
     height: data.y1 - data.y0
   });
-  const size = calculateDimensions(wrap ? key : text, fontFamily, fontSize);
+  const size = calculateDimensions(
+    typeof text === 'string' ? text : key,
+    fontFamily,
+    fontSize
+  );
 
   const offsetX =
     placement === 'start'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
Update value being passed to calculateDimensions from treeMapLabel

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If wrap is set to false but the text is too short and doesn't go through the wrap text logic, it doesn't center as expected.

## What is the new behavior?
Center text when wrap is set to false but the text is too short to require wrapping

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
The only scenario that ```wrapText``` returns a plain string is when wrap is set to false and the text is long.
<img width="471" alt="Screenshot 2023-07-12 at 10 55 35 AM" src="https://github.com/reaviz/reaviz/assets/97488700/d8268cc9-573b-45ae-9959-ddb6b3ae0650">
<img width="1008" alt="Screenshot 2023-07-12 at 10 14 04 AM" src="https://github.com/reaviz/reaviz/assets/97488700/b09ce2d3-2d8d-45c2-9590-14496a538fcd">
**Solution:**
<img width="527" alt="Screenshot 2023-07-12 at 10 57 03 AM" src="https://github.com/reaviz/reaviz/assets/97488700/ec34c9fa-2e23-487e-a23d-368698183eca">
