### PR TITLE
Generic Radial chart for all start and end angles with open/closed curve options

### DIFF
--- a/src/RadialAreaChart/RadialAreaChart.story.tsx
+++ b/src/RadialAreaChart/RadialAreaChart.story.tsx
@@ -131,7 +131,8 @@ export const SemiCircle = () => (
         }
       />
     }
-    isSemiCircle={true}
+    startAngle={-0.5 * Math.PI}
+    endAngle={0.5 * Math.PI}
   />
 );
 
@@ -159,6 +160,176 @@ export const SemiCircleMultiSeries = () => (
       />
     }
     axis={<RadialAxis type="category" />}
-    isSemiCircle={true}
+    startAngle={-0.5 * Math.PI}
+    endAngle={0.5 * Math.PI}
+  />
+);
+
+export const QuarterCircle = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="linear"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={0}
+    endAngle={0.5 * Math.PI}
+  />
+);
+
+export const QuarterMultiSeries = () => (
+  <RadialAreaChart
+    data={multiCategory}
+    height={500}
+    width={500}
+    series={
+      <RadialAreaSeries
+        type="grouped"
+        interpolation="linear"
+        area={
+          <RadialArea
+            gradient={
+              <RadialGradient
+                stops={[
+                  <GradientStop offset="0%" stopOpacity={0.1} key="start" />,
+                  <GradientStop offset="80%" stopOpacity={0.3} key="stop" />
+                ]}
+              />
+            }
+          />
+        }
+      />
+    }
+    axis={<RadialAxis type="category" />}
+    startAngle={0}
+    endAngle={0.5 * Math.PI}
+  />
+);
+
+export const CustomCircle = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="linear"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={-Math.PI}
+    endAngle={0.5 * Math.PI}
+  />
+);
+
+export const CustomCircle2 = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="linear"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={-Math.PI}
+    endAngle={-0.25 * Math.PI}
+  />
+);
+
+export const CustomCircle3 = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="linear"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={-0.75 * Math.PI}
+    endAngle={0.75 * Math.PI}
   />
 );

--- a/src/RadialAreaChart/RadialAreaChart.story.tsx
+++ b/src/RadialAreaChart/RadialAreaChart.story.tsx
@@ -100,3 +100,65 @@ export const MultiSeries = () => (
     axis={<RadialAxis type="category" />}
   />
 );
+
+export const SemiCircle = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="smooth"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    isSemiCircle={true}
+  />
+);
+
+export const SemiCircleMultiSeries = () => (
+  <RadialAreaChart
+    data={multiCategory}
+    height={500}
+    width={500}
+    series={
+      <RadialAreaSeries
+        type="grouped"
+        interpolation="linear"
+        area={
+          <RadialArea
+            gradient={
+              <RadialGradient
+                stops={[
+                  <GradientStop offset="0%" stopOpacity={0.1} key="start" />,
+                  <GradientStop offset="80%" stopOpacity={0.3} key="stop" />
+                ]}
+              />
+            }
+          />
+        }
+      />
+    }
+    axis={<RadialAxis type="category" />}
+    isSemiCircle={true}
+  />
+);

--- a/src/RadialAreaChart/RadialAreaChart.story.tsx
+++ b/src/RadialAreaChart/RadialAreaChart.story.tsx
@@ -197,10 +197,11 @@ export const QuarterCircle = () => (
     }
     startAngle={0}
     endAngle={0.5 * Math.PI}
+    isClosedCurve={false}
   />
 );
 
-export const QuarterMultiSeries = () => (
+export const QuarterCircleMultiSeries = () => (
   <RadialAreaChart
     data={multiCategory}
     height={500}
@@ -226,6 +227,7 @@ export const QuarterMultiSeries = () => (
     axis={<RadialAxis type="category" />}
     startAngle={0}
     endAngle={0.5 * Math.PI}
+    isClosedCurve={false}
   />
 );
 
@@ -261,6 +263,7 @@ export const CustomCircle = () => (
     }
     startAngle={-Math.PI}
     endAngle={0.5 * Math.PI}
+    isClosedCurve={false}
   />
 );
 
@@ -296,10 +299,47 @@ export const CustomCircle2 = () => (
     }
     startAngle={-Math.PI}
     endAngle={-0.25 * Math.PI}
+    isClosedCurve={false}
   />
 );
 
 export const CustomCircle3 = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        colorScheme="cybertron"
+        animated
+        interpolation="smooth"
+        area={<RadialArea gradient={<RadialGradient />} />}
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={10} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="inside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={-0.75 * Math.PI}
+    endAngle={0.75 * Math.PI}
+    isClosedCurve={false}
+  />
+);
+
+export const CustomCircle4 = () => (
   <RadialAreaChart
     height={500}
     width={500}
@@ -329,7 +369,8 @@ export const CustomCircle3 = () => (
         }
       />
     }
-    startAngle={-0.75 * Math.PI}
-    endAngle={0.75 * Math.PI}
+    startAngle={-0.25 * Math.PI}
+    endAngle={0.25 * Math.PI}
+    isClosedCurve={false}
   />
 );

--- a/src/RadialAreaChart/RadialAreaChart.tsx
+++ b/src/RadialAreaChart/RadialAreaChart.tsx
@@ -54,7 +54,7 @@ export interface RadialAreaChartProps extends ChartProps {
   /**
    * Whether the curve should be closed. Set to true by deafult
    */
-  isClosedCurve: boolean;
+  isClosedCurve?: boolean;
 
 }
 

--- a/src/RadialAreaChart/RadialAreaChart.tsx
+++ b/src/RadialAreaChart/RadialAreaChart.tsx
@@ -51,6 +51,11 @@ export interface RadialAreaChartProps extends ChartProps {
    */
   endAngle?: number;
 
+  /**
+   * Whether the curve should be closed. Set to true by deafult
+   */
+  isClosedCurve: boolean;
+
 }
 
 export const RadialAreaChart: FC<Partial<RadialAreaChartProps>> = ({
@@ -65,7 +70,8 @@ export const RadialAreaChart: FC<Partial<RadialAreaChartProps>> = ({
   axis,
   margins,
   startAngle,
-  endAngle
+  endAngle,
+  isClosedCurve
 }) => {
   const getXScale = useCallback(
     (points) => {
@@ -172,11 +178,12 @@ export const RadialAreaChart: FC<Partial<RadialAreaChartProps>> = ({
             innerRadius={innerRadius}
             startAngle={startAngle}
             endAngle={endAngle}
+            isClosedCurve={isClosedCurve}
           />
         </Fragment>
       );
     },
-    [getScales, data, innerRadius, axis, startAngle, endAngle, series]
+    [getScales, data, innerRadius, axis, startAngle, endAngle, series, isClosedCurve]
   );
 
   return (
@@ -202,5 +209,6 @@ RadialAreaChart.defaultProps = {
   axis: <RadialAxis />,
   margins: 75,
   startAngle: 0,
-  endAngle: 2 * Math.PI
+  endAngle: 2 * Math.PI,
+  isClosedCurve: true
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback, FC, useMemo, Fragment } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import { radialArea, curveCardinalClosed, curveLinearClosed } from 'd3-shape';
+import { radialArea, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
 import { RadialGradient, RadialGradientProps } from '../../common/Gradient';
 import { CloneElement } from 'rdk';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
@@ -66,6 +66,11 @@ export interface RadialAreaProps {
    * Gradient to apply to the area.
    */
   gradient: ReactElement<RadialGradientProps, typeof RadialGradient> | null;
+
+  /**
+   * Whether the curve should be closed. Set to true by deafult
+   */
+  isClosedCurve: boolean;
 }
 
 export const RadialArea: FC<Partial<RadialAreaProps>> = ({
@@ -80,7 +85,8 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
   xScale,
   innerRadius,
   interpolation,
-  gradient
+  gradient,
+  isClosedCurve
 }) => {
   const transition = useMemo(
     () =>
@@ -110,7 +116,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
   const getPath = useCallback(
     (d: ChartInternalShallowDataShape[]) => {
       const curve =
-        interpolation === 'smooth' ? curveCardinalClosed : curveLinearClosed;
+        interpolation === 'smooth' ? (isClosedCurve ? curveCardinalClosed : curveCardinal) : isClosedCurve ? curveLinearClosed : curveLinear;
 
       const radialFn = radialArea()
         .angle((dd: any) => xScale(dd.x))
@@ -120,7 +126,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
 
       return radialFn(d as any);
     },
-    [xScale, yScale, interpolation, innerRadius]
+    [interpolation, isClosedCurve, xScale, innerRadius, yScale]
   );
 
   const enter = useMemo(
@@ -166,5 +172,6 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
 };
 
 RadialArea.defaultProps = {
-  gradient: <RadialGradient />
+  gradient: <RadialGradient />,
+  isClosedCurve: true
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -104,10 +104,14 @@ export interface RadialAreaSeriesProps {
   tooltip: ReactElement<TooltipAreaProps, typeof TooltipArea>;
 
   /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-  isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
@@ -127,7 +131,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
   type,
   colorScheme,
   interpolation,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
   const isMulti = type === 'grouped';
@@ -249,7 +254,6 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
     [renderArea, renderSymbols]
   );
 
-  const transform = `rotate(${isSemiCircle ? -90 : 0})`;
 
   return (
     <CloneElement<TooltipAreaProps>
@@ -265,9 +269,10 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
       color={getColorForPoint}
       onValueEnter={(event) => setActiveValues(event.value)}
       onValueLeave={() => setActiveValues(null)}
-      isSemiCircle={isSemiCircle}
+      startAngle={startAngle}
+      endAngle={endAngle}
     >
-      <g clipPath={`url(#${id}-path)`} transform={transform}>
+      <g clipPath={`url(#${id}-path)`}>
         {isMulti &&
           renderMultiSeries(data as unknown as ChartInternalNestedDataShape[])}
         {!isMulti &&
@@ -286,5 +291,6 @@ RadialAreaSeries.defaultProps = {
   line: <RadialLine />,
   symbols: <RadialPointSeries />,
   tooltip: <TooltipArea />,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -102,6 +102,12 @@ export interface RadialAreaSeriesProps {
    * Tooltip for the chart area.
    */
   tooltip: ReactElement<TooltipAreaProps, typeof TooltipArea>;
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
@@ -120,7 +126,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
   outerRadius,
   type,
   colorScheme,
-  interpolation
+  interpolation,
+  isSemiCircle
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
   const isMulti = type === 'grouped';
@@ -242,6 +249,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
     [renderArea, renderSymbols]
   );
 
+  const transform = `rotate(${isSemiCircle ? -90 : 0})`;
+
   return (
     <CloneElement<TooltipAreaProps>
       element={tooltip}
@@ -256,8 +265,9 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
       color={getColorForPoint}
       onValueEnter={(event) => setActiveValues(event.value)}
       onValueLeave={() => setActiveValues(null)}
+      isSemiCircle={isSemiCircle}
     >
-      <g clipPath={`url(#${id}-path)`}>
+      <g clipPath={`url(#${id}-path)`} transform={transform}>
         {isMulti &&
           renderMultiSeries(data as unknown as ChartInternalNestedDataShape[])}
         {!isMulti &&
@@ -275,5 +285,6 @@ RadialAreaSeries.defaultProps = {
   area: <RadialArea />,
   line: <RadialLine />,
   symbols: <RadialPointSeries />,
-  tooltip: <TooltipArea />
+  tooltip: <TooltipArea />,
+  isSemiCircle: false
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -112,6 +112,11 @@ export interface RadialAreaSeriesProps {
    * End angle for the last value.
    */
   endAngle?: number;
+
+  /**
+   * Whether the curve should be closed. Set to true by deafult
+   */
+  isClosedCurve: boolean;
 }
 
 export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
@@ -132,7 +137,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
   colorScheme,
   interpolation,
   startAngle,
-  endAngle
+  endAngle,
+  isClosedCurve
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
   const isMulti = type === 'grouped';
@@ -168,6 +174,7 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             interpolation={interpolation}
             outerRadius={outerRadius}
             innerRadius={innerRadius}
+            isClosedCurve={isClosedCurve}
           />
         )}
         {line && (
@@ -181,22 +188,12 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             interpolation={interpolation}
             color={getColorForPoint}
             data={point}
+            isClosedCurve={isClosedCurve}
           />
         )}
       </>
     ),
-    [
-      animated,
-      area,
-      getColorForPoint,
-      id,
-      innerRadius,
-      interpolation,
-      line,
-      outerRadius,
-      xScale,
-      yScale
-    ]
+    [animated, area, getColorForPoint, id, innerRadius, interpolation, isClosedCurve, line, outerRadius, xScale, yScale]
   );
 
   const renderSymbols = useCallback(
@@ -292,5 +289,6 @@ RadialAreaSeries.defaultProps = {
   symbols: <RadialPointSeries />,
   tooltip: <TooltipArea />,
   startAngle: 0,
-  endAngle: 2 * Math.PI
+  endAngle: 2 * Math.PI,
+  isClosedCurve: true
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, FC } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import { radialLine, curveCardinalClosed, curveLinearClosed } from 'd3-shape';
+import { radialLine, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
 import { MotionPath, DEFAULT_TRANSITION } from '../../common/Motion';
 
@@ -54,6 +54,11 @@ export interface RadialLineProps {
    * Internal property to identify if there is a area or not.
    */
   hasArea: boolean;
+  
+  /**
+   * Whether the curve should be closed. Set to true by deafult
+   */
+  isClosedCurve: boolean;
 }
 
 export const RadialLine: FC<Partial<RadialLineProps>> = ({
@@ -66,14 +71,15 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
   data,
   interpolation,
   strokeWidth,
-  animated
+  animated,
+  isClosedCurve
 }) => {
   const fill = color(data, index);
 
   const getPath = useCallback(
     (preData: ChartInternalShallowDataShape[]) => {
       const curve =
-        interpolation === 'smooth' ? curveCardinalClosed : curveLinearClosed;
+        interpolation === 'smooth' ? (isClosedCurve ? curveCardinalClosed : curveCardinal) : isClosedCurve ? curveLinearClosed : curveLinear;
 
       const radialFn = radialLine()
         .angle((d: any) => xScale(d.x))
@@ -82,7 +88,7 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
 
       return radialFn(preData as any);
     },
-    [xScale, yScale, interpolation]
+    [interpolation, isClosedCurve, xScale, yScale]
   );
 
   const transition = useMemo(
@@ -133,5 +139,6 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
 
 RadialLine.defaultProps = {
   strokeWidth: 2,
-  animated: true
+  animated: true,
+  isClosedCurve: true
 };

--- a/src/RadialAreaChart/RadialLineChart.story.tsx
+++ b/src/RadialAreaChart/RadialLineChart.story.tsx
@@ -109,7 +109,8 @@ export const SemiCircle = () => (
         }
       />
     }
-    isSemiCircle={true}
+    startAngle={-0.5 * Math.PI}
+    endAngle={0.5 * Math.PI}
   />
 );
 
@@ -120,6 +121,7 @@ export const SemiCircleMultiSeries = () => (
     width={500}
     series={<RadialAreaSeries area={null} type="grouped" interpolation="linear" />}
     axis={<RadialAxis type="category" />}
-    isSemiCircle={true}
+    startAngle={-0.5 * Math.PI}
+    endAngle={0.5 * Math.PI}
   />
 );

--- a/src/RadialAreaChart/RadialLineChart.story.tsx
+++ b/src/RadialAreaChart/RadialLineChart.story.tsx
@@ -78,3 +78,48 @@ export const MultiSeries = () => (
     axis={<RadialAxis type="category" />}
   />
 );
+
+export const SemiCircle = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        area={null}
+        colorScheme="cybertron"
+        animated
+        interpolation="smooth"
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={5} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="outside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    isSemiCircle={true}
+  />
+);
+
+export const SemiCircleMultiSeries = () => (
+  <RadialAreaChart
+    data={multiCategory}
+    height={500}
+    width={500}
+    series={<RadialAreaSeries area={null} type="grouped" interpolation="linear" />}
+    axis={<RadialAxis type="category" />}
+    isSemiCircle={true}
+  />
+);

--- a/src/RadialAreaChart/RadialLineChart.story.tsx
+++ b/src/RadialAreaChart/RadialLineChart.story.tsx
@@ -125,3 +125,39 @@ export const SemiCircleMultiSeries = () => (
     endAngle={0.5 * Math.PI}
   />
 );
+
+export const Custom = () => (
+  <RadialAreaChart
+    height={500}
+    width={500}
+    data={medDateData}
+    innerRadius={0.1}
+    series={
+      <RadialAreaSeries
+        area={null}
+        colorScheme="cybertron"
+        animated
+        interpolation="smooth"
+      />
+    }
+    axis={
+      <RadialAxis
+        arcs={<RadialAxisArcSeries count={5} />}
+        ticks={
+          <RadialAxisTickSeries
+            count={5}
+            tick={
+              <RadialAxisTick
+                line={<RadialAxisTickLine position="outside" />}
+                label={<RadialAxisTickLabel autoRotate />}
+              />
+            }
+          />
+        }
+      />
+    }
+    startAngle={-0.25 * Math.PI}
+    endAngle={0.25 * Math.PI}
+    isClosedCurve={false}
+  />
+);

--- a/src/common/Axis/RadialAxis/RadialAxis.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxis.tsx
@@ -51,6 +51,12 @@ export interface RadialAxisProps {
     RadialAxisTickSeriesProps,
     typeof RadialAxisTickSeries
   > | null;
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
@@ -60,7 +66,8 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
   height,
   width,
   innerRadius,
-  type
+  type,
+  isSemiCircle
 }) => {
   const outerRadius = Math.min(height, width) / 2;
 
@@ -83,6 +90,7 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
           outerRadius={outerRadius}
           innerRadius={innerRadius}
           tickValues={tickValues}
+          isSemiCircle={isSemiCircle}
         />
       )}
       {ticks && (
@@ -92,6 +100,7 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
           type={type}
           innerRadius={innerRadius}
           outerRadius={outerRadius}
+          isSemiCircle={isSemiCircle}
         />
       )}
     </Fragment>
@@ -102,5 +111,6 @@ RadialAxis.defaultProps = {
   innerRadius: 10,
   type: 'value',
   arcs: <RadialAxisArcSeries />,
-  ticks: <RadialAxisTickSeries />
+  ticks: <RadialAxisTickSeries />,
+  isSemiCircle: false
 };

--- a/src/common/Axis/RadialAxis/RadialAxis.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxis.tsx
@@ -53,10 +53,14 @@ export interface RadialAxisProps {
   > | null;
 
   /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-  isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
@@ -67,7 +71,8 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
   width,
   innerRadius,
   type,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
   const outerRadius = Math.min(height, width) / 2;
 
@@ -90,7 +95,8 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
           outerRadius={outerRadius}
           innerRadius={innerRadius}
           tickValues={tickValues}
-          isSemiCircle={isSemiCircle}
+          startAngle={startAngle}
+          endAngle={endAngle}
         />
       )}
       {ticks && (
@@ -100,7 +106,8 @@ export const RadialAxis: FC<Partial<RadialAxisProps>> = ({
           type={type}
           innerRadius={innerRadius}
           outerRadius={outerRadius}
-          isSemiCircle={isSemiCircle}
+          startAngle={startAngle}
+          endAngle={endAngle}
         />
       )}
     </Fragment>
@@ -112,5 +119,6 @@ RadialAxis.defaultProps = {
   type: 'value',
   arcs: <RadialAxisArcSeries />,
   ticks: <RadialAxisTickSeries />,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArc.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArc.tsx
@@ -20,13 +20,20 @@ export interface RadialAxisArcProps {
    * Stroke dash array of the arc.
    */
   strokeDasharray: ((index: number) => string) | string;
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAxisArc: FC<Partial<RadialAxisArcProps>> = ({
   index,
   stroke,
   strokeDasharray,
-  scale
+  scale,
+  isSemiCircle
 }) => {
   const r = scale(index);
   const strokeColor = typeof stroke === 'string' ? stroke : stroke(index);
@@ -34,21 +41,33 @@ export const RadialAxisArc: FC<Partial<RadialAxisArcProps>> = ({
     typeof strokeDasharray === 'string'
       ? strokeDasharray
       : strokeDasharray(index);
+  const d = `M 0 0 h ${r} A ${r} ${r} 0 1 0 -${r} 0 z`;
 
   return (
-    <circle
-      fill="none"
-      strokeDasharray={strokeDash}
-      stroke={strokeColor}
-      style={{ pointerEvents: 'none' }}
-      cx="0"
-      cy="0"
-      r={r}
-    />
+    <>
+      {!isSemiCircle ? 
+        <circle
+          fill="none"
+          strokeDasharray={strokeDash}
+          stroke={strokeColor}
+          style={{ pointerEvents: 'none' }}
+          cx="0"
+          cy="0"
+          r={r}
+        />
+        :
+        <path d={d} fill="none"
+          strokeDasharray={strokeDash}
+          stroke={strokeColor}
+          style={{ pointerEvents: 'none' }}
+        />
+      }
+    </>
   );
 };
 
 RadialAxisArc.defaultProps = {
   stroke: '#71808d',
-  strokeDasharray: '1,4'
+  strokeDasharray: '1,4',
+  isSemiCircle: false
 };

--- a/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArcSeries.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArcSeries.tsx
@@ -37,10 +37,14 @@ export interface RadialAxisArcSeriesProps {
   tickValues?: any[];
 
   /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-  isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
@@ -50,7 +54,8 @@ export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
   line,
   arc,
   tickValues,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
   const scale = scaleLinear()
     .domain([0, count])
@@ -87,7 +92,8 @@ export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
               key={d}
               index={d}
               scale={scale}
-              isSemiCircle={isSemiCircle}
+              startAngle={startAngle}
+              endAngle={endAngle}
             />
           ))}
         </>
@@ -100,5 +106,6 @@ RadialAxisArcSeries.defaultProps = {
   type: 'arc',
   count: 12,
   arc: <RadialAxisArc />,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArcSeries.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisArcSeries/RadialAxisArcSeries.tsx
@@ -35,6 +35,12 @@ export interface RadialAxisArcSeriesProps {
    * Calculated tick values by the Radial Axis.
    */
   tickValues?: any[];
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
@@ -43,7 +49,8 @@ export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
   outerRadius,
   line,
   arc,
-  tickValues
+  tickValues,
+  isSemiCircle
 }) => {
   const scale = scaleLinear()
     .domain([0, count])
@@ -80,6 +87,7 @@ export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
               key={d}
               index={d}
               scale={scale}
+              isSemiCircle={isSemiCircle}
             />
           ))}
         </>
@@ -91,5 +99,6 @@ export const RadialAxisArcSeries: FC<Partial<RadialAxisArcSeriesProps>> = ({
 RadialAxisArcSeries.defaultProps = {
   type: 'arc',
   count: 12,
-  arc: <RadialAxisArc />
+  arc: <RadialAxisArc />,
+  isSemiCircle: false
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTick.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTick.tsx
@@ -52,6 +52,12 @@ export interface RadialAxisTickProps {
     RadialAxisTickLabelProps,
     typeof RadialAxisTickLabel
   > | null;
+
+   /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+   isSemiCircle?: boolean;
 }
 
 export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
@@ -62,10 +68,12 @@ export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
   data,
   index,
   padding,
-  innerRadius
+  innerRadius,
+  isSemiCircle
 }) => {
   const point = scale(data);
-  const rotation = (point * 180) / Math.PI - 90;
+  const rotationFactor = isSemiCircle ? 2 : 1;
+  const rotation = (point * 180) / Math.PI - (rotationFactor*90);
   const transform = `rotate(${rotation}) translate(${outerRadius + padding},0)`;
   const lineSize = line ? line.props.size : 0;
 
@@ -86,6 +94,8 @@ export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
           rotation={rotation}
           lineSize={lineSize}
           data={data}
+          isSemiCircle={isSemiCircle}
+          autoRotate={false}
         />
       )}
     </g>
@@ -96,5 +106,6 @@ RadialAxisTick.defaultProps = {
   outerRadius: 0,
   padding: 0,
   line: <RadialAxisTickLine />,
-  label: <RadialAxisTickLabel />
+  label: <RadialAxisTickLabel />,
+  isSemiCircle: false
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTick.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTick.tsx
@@ -54,10 +54,14 @@ export interface RadialAxisTickProps {
   > | null;
 
    /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-   isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
@@ -69,11 +73,12 @@ export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
   index,
   padding,
   innerRadius,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
   const point = scale(data);
-  const rotationFactor = isSemiCircle ? 2 : 1;
-  const rotation = (point * 180) / Math.PI - (rotationFactor*90);
+  
+  const rotation = (point * 180) / Math.PI - 90;
   const transform = `rotate(${rotation}) translate(${outerRadius + padding},0)`;
   const lineSize = line ? line.props.size : 0;
 
@@ -94,8 +99,9 @@ export const RadialAxisTick: FC<Partial<RadialAxisTickProps>> = ({
           rotation={rotation}
           lineSize={lineSize}
           data={data}
-          isSemiCircle={isSemiCircle}
           autoRotate={false}
+          startAngle={startAngle}
+          endAngle={endAngle}
         />
       )}
     </g>
@@ -107,5 +113,6 @@ RadialAxisTick.defaultProps = {
   padding: 0,
   line: <RadialAxisTickLine />,
   label: <RadialAxisTickLabel />,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickLabel.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickLabel.tsx
@@ -60,10 +60,14 @@ export interface RadialAxisTickLabelProps {
   format?: (value: any, index: number) => any | string;
 
   /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-  isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
@@ -78,12 +82,18 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
   format,
   lineSize,
   index,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
+ 
+  const range = Math.abs(endAngle - startAngle);
+  const isFullCircle = Math.abs(range) >= 2 * Math.PI;
+  const rotationFactor = isFullCircle || (range < Math.PI) ? 1 : (Math.PI/range);
+
   const { transform, textAnchor } = useMemo(() => {
     let textAnchor;
     let transform;
-    const rotationFactor = isSemiCircle ? 2 : 1;
+
     if (autoRotate) {
       const l = point >= Math.PI;
       const r = point < (rotationFactor * Math.PI);
@@ -102,7 +112,7 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
 
       transform = `rotate(${(rotationFactor*90) - rad2deg(point)}, ${rotationFactor*padding}, 0)`;
     } else {
-      const shouldRotate = rotation && (isSemiCircle ? rotation < -100 : rotation > 100);
+      const shouldRotate = rotation && (rotation > 100 || rotation < -100 );
       const rotate = shouldRotate ? 180 : 0;
       const translate = shouldRotate ? -30 : 0;
       textAnchor = shouldRotate ? 'end' : 'start';
@@ -113,7 +123,7 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
       transform,
       textAnchor
     };
-  }, [autoRotate, isSemiCircle, padding, point, rotation]);
+  }, [autoRotate, padding, point, rotation, rotationFactor]);
 
   const text = format ? format(data, index) : formatValue(data);
 
@@ -140,5 +150,6 @@ RadialAxisTickLabel.defaultProps = {
   padding: 15,
   fontFamily: 'sans-serif',
   autoRotate: true,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickLabel.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickLabel.tsx
@@ -58,6 +58,12 @@ export interface RadialAxisTickLabelProps {
    * Format of the label.
    */
   format?: (value: any, index: number) => any | string;
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
@@ -71,20 +77,21 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
   fontSize,
   format,
   lineSize,
-  index
+  index,
+  isSemiCircle
 }) => {
   const { transform, textAnchor } = useMemo(() => {
     let textAnchor;
     let transform;
-
+    const rotationFactor = isSemiCircle ? 2 : 1;
     if (autoRotate) {
       const l = point >= Math.PI;
-      const r = point < 2 * Math.PI;
+      const r = point < (rotationFactor * Math.PI);
 
       // TODO: This centers the text, determine better way later
       if (
-        (rotation >= 85 && rotation <= 95) ||
-        (rotation <= -85 && rotation >= -95)
+        (rotation >= (85/rotationFactor) && rotation <= (95/rotationFactor)) ||
+        (rotation <= (-85/rotationFactor) && rotation >= (-95/rotationFactor))
       ) {
         textAnchor = 'middle';
       } else if (l && r) {
@@ -93,9 +100,9 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
         textAnchor = 'start';
       }
 
-      transform = `rotate(${90 - rad2deg(point)}, ${padding}, 0)`;
+      transform = `rotate(${(rotationFactor*90) - rad2deg(point)}, ${rotationFactor*padding}, 0)`;
     } else {
-      const shouldRotate = rotation > 100 && rotation;
+      const shouldRotate = rotation && (isSemiCircle ? rotation < -100 : rotation > 100);
       const rotate = shouldRotate ? 180 : 0;
       const translate = shouldRotate ? -30 : 0;
       textAnchor = shouldRotate ? 'end' : 'start';
@@ -106,7 +113,7 @@ export const RadialAxisTickLabel: FC<Partial<RadialAxisTickLabelProps>> = ({
       transform,
       textAnchor
     };
-  }, [autoRotate, padding, point, rotation]);
+  }, [autoRotate, isSemiCircle, padding, point, rotation]);
 
   const text = format ? format(data, index) : formatValue(data);
 
@@ -132,5 +139,6 @@ RadialAxisTickLabel.defaultProps = {
   fontSize: 11,
   padding: 15,
   fontFamily: 'sans-serif',
-  autoRotate: true
+  autoRotate: true,
+  isSemiCircle: false
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
@@ -46,10 +46,14 @@ export interface RadialAxisTickSeriesProps {
   tick: ReactElement<RadialAxisTickProps, typeof RadialAxisTick>;
 
   /**
-   * Whether to render a semicircle or a full circle
-   * Renders a full circle by default
+   * Start angle for the first value.
    */
-  isSemiCircle?: boolean;
+  startAngle?: number;
+
+  /**
+   * End angle for the last value.
+   */
+  endAngle?: number;
 }
 
 export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
@@ -61,7 +65,8 @@ export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
   innerRadius,
   interval,
   type,
-  isSemiCircle
+  startAngle,
+  endAngle
 }) => {
   const ticks = getTicks(scale, tickValues, type, count, interval || count);
 
@@ -76,7 +81,8 @@ export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
           data={data}
           innerRadius={innerRadius}
           outerRadius={outerRadius}
-          isSemiCircle={isSemiCircle}
+          startAngle={startAngle}
+          endAngle={endAngle}
         />
       ))}
     </Fragment>
@@ -87,5 +93,6 @@ RadialAxisTickSeries.defaultProps = {
   count: 12,
   type: 'time',
   tick: <RadialAxisTick />,
-  isSemiCircle: false
+  startAngle: 0,
+  endAngle: 2 * Math.PI
 };

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
@@ -44,6 +44,12 @@ export interface RadialAxisTickSeriesProps {
    * Tick element to render.
    */
   tick: ReactElement<RadialAxisTickProps, typeof RadialAxisTick>;
+
+  /**
+   * Whether to render a semicircle or a full circle
+   * Renders a full circle by default
+   */
+  isSemiCircle?: boolean;
 }
 
 export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
@@ -54,7 +60,8 @@ export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
   tickValues,
   innerRadius,
   interval,
-  type
+  type,
+  isSemiCircle
 }) => {
   const ticks = getTicks(scale, tickValues, type, count, interval || count);
 
@@ -69,6 +76,7 @@ export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
           data={data}
           innerRadius={innerRadius}
           outerRadius={outerRadius}
+          isSemiCircle={isSemiCircle}
         />
       ))}
     </Fragment>
@@ -78,5 +86,6 @@ export const RadialAxisTickSeries: FC<Partial<RadialAxisTickSeriesProps>> = ({
 RadialAxisTickSeries.defaultProps = {
   count: 12,
   type: 'time',
-  tick: <RadialAxisTick />
+  tick: <RadialAxisTick />,
+  isSemiCircle: false
 };

--- a/src/common/Gradient/RadialGradient.story.tsx
+++ b/src/common/Gradient/RadialGradient.story.tsx
@@ -39,6 +39,7 @@ export const SemiCirlce = () => (
         interpolation="linear"
       />
     }
-    isSemiCircle={true}
+    startAngle={-0.5 * Math.PI}
+    endAngle={0.5 * Math.PI}
   />
 );

--- a/src/common/Gradient/RadialGradient.story.tsx
+++ b/src/common/Gradient/RadialGradient.story.tsx
@@ -26,3 +26,19 @@ export const Simple = () => (
     }
   />
 );
+
+export const SemiCirlce = () => (
+  <RadialAreaChart
+    data={categoryData}
+    height={500}
+    width={500}
+    axis={<RadialAxis type="category" />}
+    series={
+      <RadialAreaSeries
+        area={<RadialArea gradient={<RadialGradient />} />}
+        interpolation="linear"
+      />
+    }
+    isSemiCircle={true}
+  />
+);

--- a/src/common/Gradient/RadialGradient.story.tsx
+++ b/src/common/Gradient/RadialGradient.story.tsx
@@ -43,3 +43,21 @@ export const SemiCirlce = () => (
     endAngle={0.5 * Math.PI}
   />
 );
+
+export const Custom = () => (
+  <RadialAreaChart
+    data={categoryData}
+    height={500}
+    width={500}
+    axis={<RadialAxis type="category" />}
+    series={
+      <RadialAreaSeries
+        area={<RadialArea gradient={<RadialGradient />} />}
+        interpolation="smooth"
+      />
+    }
+    startAngle={-0.25 * Math.PI}
+    endAngle={0.25 * Math.PI}
+    isClosedCurve={false}
+  />
+);

--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -147,7 +147,7 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(({
   const [prevX, setPrevX] = useState<number>();
   const [prevY, setPrevY] = useState<number>();
   const ref = useRef<SVGRectElement | SVGPathElement | any>();
-  const fullCircleref = useRef<SVGRectElement | SVGPathElement | any>();
+  const fullCircleref = useRef<SVGRectElement | SVGPathElement | any>(null);
   const isFullCircle = Math.abs(endAngle - startAngle) >= 2 * Math.PI;
   
   const range = Math.abs(endAngle - startAngle);

--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -378,8 +378,8 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(({
 
 
     // This is a dummuy full circle in the background as we need the
-    // full circle to get the coordinates right from getBoundingClientRect()
-    // If we don't use a full circle the bounding circle could be of any dimension and
+    // full circle to get the coordinates right from getBoundingClientRect().
+    // If we don't use a full circle, then the bounding rectangle could be of any dimension and
     // the logic in getPositionForTarget() wouldn't work
     const fullCircle = arc()({
       innerRadius: innerRadiusNew,

--- a/src/common/utils/position.ts
+++ b/src/common/utils/position.ts
@@ -7,14 +7,15 @@ type PointObjectNotation = { x: number; y: number };
  * Add ability to calculate scale band position.
  * Reference: https://stackoverflow.com/questions/38633082/d3-getting-invert-value-of-band-scales
  */
-const scaleBandInvert = (scale) => {
+const scaleBandInvert = (scale, isPointScale=false) => {
   const domain = scale.domain();
   const paddingOuter = scale(domain[0]);
   const eachBand = scale.step();
   const [, end] = scale.range();
 
   return (offset) => {
-    let index = Math.floor((offset - paddingOuter) / eachBand);
+    const band = (offset - paddingOuter) / eachBand;
+    let index = isPointScale ? Math.round(band): Math.floor(band);
 
     // Handle horizontal charts...
     if (end === 0) {
@@ -28,7 +29,7 @@ const scaleBandInvert = (scale) => {
 /**
  * Given a point position, get the closes data point in the dataset.
  */
-export const getClosestPoint = (pos: number, scale, data, attr = 'x') => {
+export const getClosestPoint = (pos: number, scale, data, attr = 'x', isPointScale=false) => {
   if (scale.invert) {
     const domain = scale.invert(pos);
 
@@ -60,7 +61,7 @@ export const getClosestPoint = (pos: number, scale, data, attr = 'x') => {
     if (scale.mariemkoInvert) {
       prop = scale.mariemkoInvert(pos);
     } else {
-      prop = scaleBandInvert(scale)(pos);
+      prop = scaleBandInvert(scale, isPointScale)(pos);
     }
 
     const idx = domain.indexOf(prop);

--- a/src/common/utils/position.ts
+++ b/src/common/utils/position.ts
@@ -1,5 +1,5 @@
 import { bisector } from 'd3-array';
-import { applyToPoint, inverse, applyToPoints } from 'transformation-matrix';
+import { applyToPoint, applyToPoints, inverse } from 'transformation-matrix';
 
 type PointObjectNotation = { x: number; y: number };
 
@@ -28,6 +28,8 @@ const scaleBandInvert = (scale, isPointScale=false) => {
 
 /**
  * Given a point position, get the closes data point in the dataset.
+ * @param isPointScale Set to true if the scale being used is scalePoint (https://www.d3indepth.com/scales/#scalepoint)
+ *                      as it's slightly different from scaleBand (https://www.d3indepth.com/scales/#scaleband)
  */
 export const getClosestPoint = (pos: number, scale, data, attr = 'x', isPointScale=false) => {
   if (scale.invert) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the radial chart only renders a complete circle.

Issue Number: N/A


## What is the new behavior?
It now supports rendering a radial chart of any dimension(sector) by setting the newly added `startAngle` and `endAngle` properties. The chart is rendered from  the `startAngle` to the `endAngle` in the **clockwise direction**.

Additionally, a `isClosedCurve` property has been added if closed interpolation of line/area curve is not required (which may be required in cases other than a full circle).



https://github.com/reaviz/reaviz/assets/33908100/aa4cd079-9cfe-4331-bfb6-681ad130c965





## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
