### PR TITLE
Fix: tooltip for custom radial charts which don't occupy full height/width of the container 

### DIFF
--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -158,8 +158,8 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(({
   const getXCoord = useCallback((x: number, y: number) => {
     // If the shape is radial, we need to convert the X coords to a radial format.
     if (isRadial) {
-      const outerRadius = Math.min(width, height) / 2;
-      let rad = Math.atan2(y - outerRadius, x - outerRadius) + (rotationFactor * Math.PI);
+      const outerRadiusNew = outerRadius || (Math.min(width, height) / 2);
+      let rad = Math.atan2(y - outerRadiusNew, x - outerRadiusNew) + (rotationFactor * Math.PI);
 
       // Align it with the expected start angle
       rad = (rad - startAngle) % (2 * Math.PI);


### PR DESCRIPTION
This PR fixes the issue with the tooltips in those radial charts where the chart does not occupy the complete height/width of it's container. This is specially true for custom charts with multiple types of components (series, bars, etc.) within it.