### PR TITLE
GOOD-85: Add positioning and conditional display to FunnelChart labels

### DIFF
--- a/src/FunnelChart/FunnelChart.story.tsx
+++ b/src/FunnelChart/FunnelChart.story.tsx
@@ -101,3 +101,40 @@ export const Layered = () => (
     }
   />
 );
+
+export const LabelPosition = () => (
+  <FunnelChart
+    height={300}
+    width={500}
+    series={
+      <FunnelSeries
+        axis={<FunnelAxis label={<FunnelAxisLabel position="bottom" />} />}
+      />
+    }
+    data={[
+      { key: 'Visited Site', data: 1000 },
+      { key: 'Added to Cart', data: 900 },
+      { key: 'Initiated Checkout', data: 600 },
+      { key: 'Purchased', data: 400 }
+    ]}
+  />
+);
+
+export const NoValue = () => (
+  <FunnelChart
+    height={300}
+    width={500}
+    series={
+      <FunnelSeries
+        arc={<FunnelArc tooltip={<TooltipArea />} />}
+        axis={<FunnelAxis label={<FunnelAxisLabel showValue={false} />} />}
+      />
+    }
+    data={[
+      { key: 'Visited Site', data: 1000 },
+      { key: 'Added to Cart', data: 900 },
+      { key: 'Initiated Checkout', data: 600 },
+      { key: 'Purchased', data: 400 }
+    ]}
+  />
+);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently you cannot change a Funnel Chart's label position, prevent the label from hiding when the width is too great, or hide the value of the segment data in the label

Issue Number: [GOOD-85](https://linear.app/goodcodeus/issue/GOOD-85/update-funnelchart-labels)


## What is the new behavior?
Now you can:
- Change a label's position to `top`, `center`, or `bottom`
- Always show the label
- Hide the value of a segment's data in the label

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

![Screenshot 2023-10-16 at 3 27 54 PM](https://github.com/reaviz/reaviz/assets/40581813/298e27b6-ab6b-492e-b06e-47f31e40fbd3)
![Screenshot 2023-10-16 at 3 28 01 PM](https://github.com/reaviz/reaviz/assets/40581813/29784993-61a6-4fca-8ce8-de42dd593e79)

