### PR TITLE
Bugfix/long FunnelChart labels crashing UI

### DIFF
--- a/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
@@ -115,7 +115,7 @@ export const FunnelAxisLabel: FC<Partial<FunnelAxisLabelProps>> = ({
     case 'bottom':
       {
         // If the text is wrapping, we need to account for the height of all the lines
-        const textWrapHeight = text.length
+        const textWrapHeight = text?.length
           ? text.slice(1).reduce((acc, curr) => acc + curr.props.dy, 0) // Don't include first line's dy in order to align properly
           : 0;
         transform = `translate(${x}, ${height - padding - textWrapHeight})`;

--- a/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
@@ -116,7 +116,7 @@ export const FunnelAxisLabel: FC<Partial<FunnelAxisLabelProps>> = ({
     case 'bottom':
       {
         // If the text is wrapping, we need to account for the height of all the lines
-        const textWrapHeight = text?.length
+        const textWrapHeight = Array.isArray(text)
           ? text.slice(1).reduce((acc, curr) => acc + curr.props.dy, 0) // Don't include first line's dy in order to align properly
           : 0;
         transform = `translate(${x}, ${height - padding - textWrapHeight})`;

--- a/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelAxis/FunnelAxisLabel.tsx
@@ -99,7 +99,8 @@ export const FunnelAxisLabel: FC<Partial<FunnelAxisLabelProps>> = ({
     width,
     height,
     fontFamily,
-    fontSize
+    fontSize,
+    visibility: labelVisibility
   });
 
   const getTransformString = useCallback(() => {

--- a/src/common/utils/wrapText.tsx
+++ b/src/common/utils/wrapText.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { calculateDimensions } from './size';
 
 export interface WrapTextInputs {
@@ -30,7 +30,7 @@ export function wrapText({
   fontFamily,
   fontSize,
   visibility = 'auto'
-}: WrapTextInputs) {
+}: WrapTextInputs): ReactElement | ReactElement[] | null {
   size = size || calculateDimensions(key, fontFamily, fontSize);
   const words = key.toString().split(/\s+/);
 

--- a/src/common/utils/wrapText.tsx
+++ b/src/common/utils/wrapText.tsx
@@ -15,6 +15,7 @@ export interface WrapTextInputs {
     width: number;
     height: number;
   };
+  visibility?: 'auto' | 'always';
 }
 
 export function wrapText({
@@ -27,7 +28,8 @@ export function wrapText({
   width,
   height,
   fontFamily,
-  fontSize
+  fontSize,
+  visibility = 'auto'
 }: WrapTextInputs) {
   size = size || calculateDimensions(key, fontFamily, fontSize);
   const words = key.toString().split(/\s+/);
@@ -58,12 +60,14 @@ export function wrapText({
     rows.push(curText);
     maxHeight = rows.length * size.height;
 
-    if (height && maxHeight >= height - (paddingY ? 2 * paddingY : 0)) {
-      return null;
-    }
+    if (visibility !== 'always') {
+      if (height && maxHeight >= height - (paddingY ? 2 * paddingY : 0)) {
+        return null;
+      }
 
-    if (width && maxWidth >= width - (paddingX ? 2 * paddingX : 0)) {
-      return null;
+      if (width && maxWidth >= width - (paddingX ? 2 * paddingX : 0)) {
+        return null;
+      }
     }
 
     if (!wrap && rows.length > 1) {
@@ -89,12 +93,14 @@ export function wrapText({
     ));
   }
 
-  if (height && size.height + paddingY >= height) {
-    return null;
-  }
+  if (visibility !== 'always') {
+    if (height && size.height + paddingY >= height) {
+      return null;
+    }
 
-  if (width && size.width + paddingX >= width) {
-    return null;
+    if (width && size.width + paddingX >= width) {
+      return null;
+    }
   }
 
   // NOTE: 5px seems to magic number for making it center


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using a FunnelChart label that is very long causes the UI to crash. This is because at a certain input length the `wrapText()` util returns `null` instead of a `tspan`

Issue Number: N/A


## What is the new behavior?
Using very long FunnelChart labels won't crash the UI. I also added the option to always return the wrapped text from `wrapText()` regardless of the length

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
