### PR TITLE
Feature/Add ability to build Stacked arcs for StackedRadialGaugeSeries

### DIFF
--- a/demo/category.ts
+++ b/demo/category.ts
@@ -26,6 +26,30 @@ export const categoryData = [
   }
 ];
 
+export const categoryDataStackedArcs = [
+  {
+    key: 'Third Party',
+    data: 40,
+  },
+  {
+    key: 'Phishing Attack',
+    data: [
+      {
+        key: 'Malware',
+        data: 10
+      },
+      {
+        key: 'DLP',
+        data: 16
+      },
+    ],
+  },
+  {
+    key: 'IDS',
+    data: 26,
+  },
+];
+
 export const durationCategoryData = [
   {
     key: 'Phishing Attack',

--- a/src/RadialGauge/RadialGauge.story.tsx
+++ b/src/RadialGauge/RadialGauge.story.tsx
@@ -177,7 +177,12 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
   }
 
   const descriptionElement = (
-    <>
+    <text
+      x="0"
+      y={-20}
+      textAnchor="middle"
+      alignmentBaseline="middle"
+    >
       <tspan x="0" fontSize={16} fontWeight={700} fill={'#E9E9E9'}>
         Hours Complete
       </tspan>
@@ -190,7 +195,7 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
         </tspan>
         from last week
       </tspan>
-    </>
+    </text>
   );
 
   return (
@@ -207,9 +212,7 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
           arcPadding={0.5}
           fillFactor={0.3}
           colorScheme={colorSchema}
-          descriptionLabel={
-            <StackedRadialGaugeDescriptionLabel label={descriptionElement} />
-          }
+          descriptionLabel={descriptionElement}
         />
       }
     />

--- a/src/RadialGauge/RadialGauge.story.tsx
+++ b/src/RadialGauge/RadialGauge.story.tsx
@@ -1,5 +1,5 @@
 import { RadialGauge } from './RadialGauge';
-import { categoryData } from '../../demo';
+import { categoryData, categoryDataStackedArcs } from '../../demo';
 import {
   RadialGaugeArc,
   RadialGaugeSeries,
@@ -9,6 +9,9 @@ import {
 } from './RadialGaugeSeries';
 import { Gradient } from '../common/Gradient';
 import { max } from 'd3-array';
+import { ChartDataShape, ColorSchemeType } from '../common';
+import React from 'react';
+import { StoryFn } from '@storybook/react';
 
 export default {
   title: 'Charts/Gauge/Radial'
@@ -72,7 +75,7 @@ export const CustomArc = () => (
 );
 
 export const Multi = () => {
-  const maxValue = max(categoryData, d => d.data as number);
+  const maxValue = max(categoryData, (d) => d.data as number);
   const colorScheme: string[] = ['#CE003E', '#DF8D03', '#00ECB1', '#9FA9B1'];
 
   return (
@@ -124,6 +127,116 @@ export const Stacked = () => {
       }
     />
   );
+};
+
+interface GaugeStackedTemplateProps {
+  width: number;
+  height: number;
+  data: ChartDataShape[];
+  maxValue?: number;
+  colorSchemaType: 'handlerFn' | 'array' | 'string';
+}
+
+const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
+  const calculatedMaxValue = max(args.data, (d) => {
+    const dataValue = d.data;
+    if (Array.isArray(dataValue)) {
+      return dataValue.reduce((acc: number, curr) => acc + curr.data, 0);
+    }
+
+    return dataValue;
+  });
+
+  const defaultColor = '#948d62';
+  const customColorScheme: Record<string, string> = {
+    'Third Party': '#DF8D03',
+    Malware: '#993FFF',
+    DLP: '#D9C0FF',
+    IDS: '#00FFC7'
+  };
+  const colorSchemeHandler = (data: ChartDataShape) => {
+    const key = data.key;
+    if (typeof key === 'string' && customColorScheme[key]) {
+      return customColorScheme[key];
+    }
+
+    return defaultColor;
+  };
+  const colorSchemeArr: string[] = ['#c42656', '#03df2f', '#6747b4', '#ccd016'];
+
+  let colorSchema: ColorSchemeType;
+  switch (args.colorSchemaType) {
+    case 'handlerFn':
+      colorSchema = colorSchemeHandler;
+      break;
+    case 'array':
+      colorSchema = colorSchemeArr;
+      break;
+    default:
+      colorSchema = defaultColor;
+  }
+
+  const descriptionElement = (
+    <>
+      <tspan x="0" fontSize={16} fontWeight={700} fill={'#E9E9E9'}>
+        Hours Complete
+      </tspan>
+      <tspan x="0" dy="1.2em" fontSize={32} fontWeight={800} fill={'#FFFFFF'}>
+        67%
+      </tspan>
+      <tspan x="0" dy="1.5em" fontSize={14} fill={'#c2b0e7'}>
+        <tspan fontWeight="bold" fill={'#00E5AF'}>
+          ↑ 4%
+        </tspan>
+        from last week
+      </tspan>
+    </>
+  );
+
+  return (
+    <RadialGauge
+      data={args.data}
+      startAngle={0}
+      endAngle={Math.PI * 2}
+      height={args.height}
+      width={args.width}
+      minValue={0}
+      maxValue={args.maxValue || calculatedMaxValue}
+      series={
+        <StackedRadialGaugeSeries
+          arcPadding={0.5}
+          fillFactor={0.3}
+          colorScheme={colorSchema}
+          descriptionLabel={
+            <StackedRadialGaugeDescriptionLabel label={descriptionElement} />
+          }
+        />
+      }
+    />
+  );
+};
+
+export const GaugeStacked = GaugeStackedTemplate.bind({});
+GaugeStacked.args = {
+  width: 700,
+  height: 300,
+  data: categoryDataStackedArcs,
+  maxValue: undefined,
+  colorSchemaType: 'handlerFn'
+};
+GaugeStacked.argTypes = {
+  width: { control: { type: 'number', min: 300, max: 700, step: 10 } },
+  height: { control: { type: 'number', min: 300, max: 700, step: 10 } },
+  data: {
+    type: 'object'
+  },
+  maxValue: {
+    type: 'number'
+  },
+  colorSchemaType: {
+    control: 'inline-radio',
+    options: ['handlerFn', 'array', 'string']
+  }
 };
 
 export const Autosize = () => (

--- a/src/RadialGauge/RadialGauge.story.tsx
+++ b/src/RadialGauge/RadialGauge.story.tsx
@@ -137,8 +137,14 @@ interface GaugeStackedTemplateProps {
   colorSchemaType: 'handlerFn' | 'array' | 'string';
 }
 
-const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
-  const calculatedMaxValue = max(args.data, (d) => {
+const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = ({
+  width,
+  height,
+  data,
+  maxValue,
+  colorSchemaType,
+}) => {
+  const calculatedMaxValue = max(data, (d) => {
     const dataValue = d.data;
     if (Array.isArray(dataValue)) {
       return dataValue.reduce((acc: number, curr) => acc + curr.data, 0);
@@ -165,7 +171,7 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
   const colorSchemeArr: string[] = ['#c42656', '#03df2f', '#6747b4', '#ccd016'];
 
   let colorSchema: ColorSchemeType;
-  switch (args.colorSchemaType) {
+  switch (colorSchemaType) {
     case 'handlerFn':
       colorSchema = colorSchemeHandler;
       break;
@@ -177,20 +183,15 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
   }
 
   const descriptionElement = (
-    <text
-      x="0"
-      y={-20}
-      textAnchor="middle"
-      alignmentBaseline="middle"
-    >
-      <tspan x="0" fontSize={16} fontWeight={700} fill={'#E9E9E9'}>
+    <text x="0" y={-20} textAnchor="middle" alignmentBaseline="middle">
+      <tspan x="0" fontSize={16} fontWeight={700} fill="#E9E9E9">
         Hours Complete
       </tspan>
-      <tspan x="0" dy="1.2em" fontSize={32} fontWeight={800} fill={'#FFFFFF'}>
+      <tspan x="0" dy="1.2em" fontSize={32} fontWeight={800} fill="#FFFFFF">
         67%
       </tspan>
-      <tspan x="0" dy="1.5em" fontSize={14} fill={'#c2b0e7'}>
-        <tspan fontWeight="bold" fill={'#00E5AF'}>
+      <tspan x="0" dy="1.5em" fontSize={14} fill="#c2b0e7">
+        <tspan fontWeight="bold" fill="#00E5AF">
           ↑ 4%
         </tspan>
         from last week
@@ -200,13 +201,13 @@ const GaugeStackedTemplate: StoryFn<GaugeStackedTemplateProps> = (args) => {
 
   return (
     <RadialGauge
-      data={args.data}
+      data={data}
       startAngle={0}
       endAngle={Math.PI * 2}
-      height={args.height}
-      width={args.width}
+      height={height}
+      width={width}
       minValue={0}
-      maxValue={args.maxValue || calculatedMaxValue}
+      maxValue={maxValue || calculatedMaxValue}
       series={
         <StackedRadialGaugeSeries
           arcPadding={0.5}

--- a/src/RadialGauge/RadialGauge.tsx
+++ b/src/RadialGauge/RadialGauge.tsx
@@ -1,7 +1,11 @@
 import React, { cloneElement, FC, ReactElement, useCallback } from 'react';
 import { scaleLinear } from 'd3-scale';
-import { ChartContainer, ChartContextProps, ChartProps } from '../common/containers';
-import { ChartShallowDataShape } from '../common/data';
+import {
+  ChartContainer,
+  ChartContextProps,
+  ChartProps
+} from '../common/containers';
+import { ChartDataShape } from '../common/data';
 import { RadialGaugeSeries, RadialGaugeSeriesProps } from './RadialGaugeSeries';
 import { useId } from 'rdk';
 
@@ -9,7 +13,7 @@ export interface RadialGaugeProps extends ChartProps {
   /**
    * Data the chart will receive to render.
    */
-  data: ChartShallowDataShape[];
+  data: ChartDataShape[];
 
   /**
    * Min value to scale on.

--- a/src/RadialGauge/RadialGauge.tsx
+++ b/src/RadialGauge/RadialGauge.tsx
@@ -6,7 +6,12 @@ import {
   ChartProps
 } from '../common/containers';
 import { ChartDataShape } from '../common/data';
-import { RadialGaugeSeries, RadialGaugeSeriesProps } from './RadialGaugeSeries';
+import {
+  RadialGaugeSeries,
+  RadialGaugeSeriesProps,
+  StackedRadialGaugeSeries,
+  StackedRadialGaugeSeriesProps
+} from './RadialGaugeSeries';
 import { useId } from 'rdk';
 
 export interface RadialGaugeProps extends ChartProps {
@@ -38,7 +43,10 @@ export interface RadialGaugeProps extends ChartProps {
   /**
    * Gauge series component to render.
    */
-  series?: ReactElement<RadialGaugeSeriesProps, typeof RadialGaugeSeries>;
+  series?: ReactElement<
+    RadialGaugeSeriesProps | StackedRadialGaugeSeriesProps,
+    typeof RadialGaugeSeries | typeof StackedRadialGaugeSeries
+  >;
 }
 
 export const RadialGauge: FC<RadialGaugeProps> = ({

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeArc.tsx
@@ -127,17 +127,16 @@ export const RadialGaugeArc: FC<Partial<RadialGaugeArcProps>> = ({
       .cornerRadius(cornerRadius);
   }, [innerRadius, outerRadius, cornerRadius]);
 
-  const arcData: ArcData = {
-    // @ts-ignore Data must be passed
-    data: data || {},
-    startAngle,
-    endAngle,
-    padAngle
-  };
+  const arcElement = useMemo(() => {
+    const arcData: ArcData = {
+      // @ts-ignore Data must be passed
+      data: data || {},
+      startAngle,
+      endAngle,
+      padAngle
+    };
 
-  return (
-    <g>
-      {fill && <circle fill={fill} r={outerRadius} />}
+    return (
       <PieArc
         id={id}
         arc={arcGenerator}
@@ -151,6 +150,28 @@ export const RadialGaugeArc: FC<Partial<RadialGaugeArcProps>> = ({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       />
+    );
+  }, [
+    id,
+    arcGenerator,
+    startAngle,
+    endAngle,
+    padAngle,
+    data,
+    animated,
+    color,
+    gradient,
+    disabled,
+    tooltip,
+    onClick,
+    onMouseEnter,
+    onMouseLeave
+  ]);
+
+  return (
+    <g>
+      {fill && <circle fill={fill} r={outerRadius} />}
+      {arcElement}
     </g>
   );
 };

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { range, min } from 'd3-array';
 import { scaleBand } from 'd3-scale';
-import { ChartShallowDataShape } from '../../common/data';
+import { ChartDataShape, ChartShallowDataShape } from '../../common/data';
 import { ColorSchemeType, getColor } from '../../common/color';
 import { RadialGaugeArc, RadialGaugeArcProps } from './RadialGaugeArc';
 import { RadialGaugeLabel, RadialGaugeLabelProps } from './RadialGaugeLabel';
@@ -28,7 +28,7 @@ export interface RadialGaugeSeriesProps {
   /**
    * Data to render set by `RadialGauge` component.
    */
-  data: ChartShallowDataShape[];
+  data: ChartDataShape[];
 
   /**
    * D3 scale function set by `RadialGauge` component.

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
@@ -28,7 +28,7 @@ export interface RadialGaugeSeriesProps {
   /**
    * Data to render set by `RadialGauge` component.
    */
-  data: ChartDataShape[];
+  data: ChartShallowDataShape[];
 
   /**
    * D3 scale function set by `RadialGauge` component.

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { range, min } from 'd3-array';
 import { scaleBand } from 'd3-scale';
-import { ChartDataShape, ChartShallowDataShape } from '../../common/data';
+import { ChartShallowDataShape } from '../../common/data';
 import { ColorSchemeType, getColor } from '../../common/color';
 import { RadialGaugeArc, RadialGaugeArcProps } from './RadialGaugeArc';
 import { RadialGaugeLabel, RadialGaugeLabelProps } from './RadialGaugeLabel';

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeSeries.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { range, min } from 'd3-array';
 import { scaleBand } from 'd3-scale';
-import { ChartShallowDataShape } from '../../common/data';
+import { ChartDataShape, ChartShallowDataShape } from '../../common';
 import { ColorSchemeType, getColor } from '../../common/color';
 import { RadialGaugeArc, RadialGaugeArcProps } from './RadialGaugeArc';
 import { RadialGaugeLabel, RadialGaugeLabelProps } from './RadialGaugeLabel';
@@ -28,7 +28,7 @@ export interface RadialGaugeSeriesProps {
   /**
    * Data to render set by `RadialGauge` component.
    */
-  data: ChartShallowDataShape[];
+  data: ChartDataShape[];
 
   /**
    * D3 scale function set by `RadialGauge` component.

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
@@ -13,7 +13,7 @@ import { RadialGaugeArcProps } from './RadialGaugeArc';
 
 export type RadialGaugeStackedArcProps = Omit<
   RadialGaugeArcProps,
-  'startAngle' | 'endAngle' | 'data' | 'color'
+  'endAngle' | 'data' | 'color'
 > & {
   /**
    * Data set by the `StackedRadialGaugeSeries` components.
@@ -39,6 +39,7 @@ export const RadialGaugeStackedArc: FC<Partial<RadialGaugeStackedArcProps>> = ({
   outerRadius,
   cornerRadius,
   padAngle,
+  startAngle,
   colorScheme,
   ...restProps
 }) => {
@@ -50,7 +51,7 @@ export const RadialGaugeStackedArc: FC<Partial<RadialGaugeStackedArcProps>> = ({
   }, [innerRadius, outerRadius, cornerRadius]);
 
   const stackedArcs = useMemo(() => {
-    let prevEndAngle = 0;
+    let prevEndAngle = startAngle;
 
     function renderArc(
       point: ChartShallowDataShape,
@@ -92,7 +93,7 @@ export const RadialGaugeStackedArc: FC<Partial<RadialGaugeStackedArcProps>> = ({
     }
 
     return data.data.map(renderArc);
-  }, [arcGenerator, colorScheme, data, padAngle, restProps, scale]);
+  }, [arcGenerator, colorScheme, data, padAngle, restProps, scale, startAngle]);
 
   return <g key={id}>{stackedArcs}</g>;
 };

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
@@ -1,0 +1,107 @@
+import React, { FC, JSX, useMemo } from 'react';
+import { arc } from 'd3-shape';
+
+import {
+  ChartNestedDataShape,
+  ChartShallowDataShape,
+  ChartTooltip,
+  ColorSchemeType,
+  getColor
+} from '../../common';
+import { ArcData, PieArc } from '../../PieChart';
+import { RadialGaugeArcProps } from './RadialGaugeArc';
+
+export type RadialGaugeStackedArcProps = Omit<
+  RadialGaugeArcProps,
+  'startAngle' | 'endAngle' | 'data' | 'color'
+> & {
+  /**
+   * Data set by the `StackedRadialGaugeSeries` components.
+   */
+  data: ChartNestedDataShape;
+
+  /**
+   * D3 scale function set by `RadialGauge` component.
+   */
+  scale: (x: number) => number;
+
+  /**
+   * Color scheme to apply set by 'StackedRadialGaugeSeries' component.
+   */
+  colorScheme: ColorSchemeType;
+};
+
+export const RadialGaugeStackedArc: FC<Partial<RadialGaugeStackedArcProps>> = ({
+  id,
+  data,
+  scale,
+  innerRadius,
+  outerRadius,
+  cornerRadius,
+  padAngle,
+  colorScheme,
+  ...restProps
+}) => {
+  const arcGenerator = useMemo(() => {
+    return arc<ArcData>()
+      .innerRadius(innerRadius)
+      .outerRadius(outerRadius)
+      .cornerRadius(cornerRadius);
+  }, [innerRadius, outerRadius, cornerRadius]);
+
+  const stackedArcs = useMemo(() => {
+    let prevEndAngle = 0;
+
+    function renderArc(
+      point: ChartShallowDataShape,
+      index: number
+    ): JSX.Element {
+      const value = point.data as number;
+      const startAngle = prevEndAngle;
+      const endAngle = startAngle + scale(value);
+      prevEndAngle = endAngle;
+
+      const arcData: ArcData = {
+        data: point,
+        startAngle,
+        endAngle,
+        padAngle,
+        value,
+        index
+      };
+
+      const color = getColor({
+        colorScheme,
+        data: [data],
+        point: point,
+        index,
+        active: [data],
+        isMultiSeries: true
+      });
+
+      return (
+        <PieArc
+          {...restProps}
+          id={point.key.toLocaleString()}
+          key={point.key.toLocaleString()}
+          arc={arcGenerator}
+          data={arcData}
+          color={color}
+        />
+      );
+    }
+
+    return data.data.map(renderArc);
+  }, [arcGenerator, colorScheme, data, padAngle, restProps, scale]);
+
+  return <g key={id}>{stackedArcs}</g>;
+};
+
+RadialGaugeStackedArc.defaultProps = {
+  cornerRadius: 0,
+  padAngle: 0,
+  padRadius: 0,
+  animated: true,
+  disabled: false,
+  tooltip: <ChartTooltip />
+};

--- a/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/RadialGaugeStackedArc.tsx
@@ -58,14 +58,14 @@ export const RadialGaugeStackedArc: FC<Partial<RadialGaugeStackedArcProps>> = ({
       index: number
     ): JSX.Element {
       const value = point.data as number;
-      const startAngle = prevEndAngle;
-      const endAngle = startAngle + scale(value);
-      prevEndAngle = endAngle;
+      const startArcAngle = prevEndAngle;
+      const endArcAngle = startArcAngle + scale(value) - startAngle;
+      prevEndAngle = endArcAngle;
 
       const arcData: ArcData = {
         data: point,
-        startAngle,
-        endAngle,
+        startAngle: startArcAngle,
+        endAngle: endArcAngle,
         padAngle,
         value,
         index

--- a/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeDescriptionLabel/StackedRadialGaugeDescriptionLabel.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeDescriptionLabel/StackedRadialGaugeDescriptionLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, JSX } from 'react';
+import React, { FC } from 'react';
 import classNames from 'classnames';
 import css from './StackedRadialGaugeDescriptionLabel.module.css';
 
@@ -6,7 +6,7 @@ export interface StackedRadialGaugeDescriptionLabelProps {
   /**
    * A label shown at the center
    */
-  label: string | JSX.Element;
+  label: string;
 
   /**
    * A class name to apply

--- a/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeDescriptionLabel/StackedRadialGaugeDescriptionLabel.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeDescriptionLabel/StackedRadialGaugeDescriptionLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, JSX } from 'react';
 import classNames from 'classnames';
 import css from './StackedRadialGaugeDescriptionLabel.module.css';
 
@@ -6,7 +6,7 @@ export interface StackedRadialGaugeDescriptionLabelProps {
   /**
    * A label shown at the center
    */
-  label: string;
+  label: string | JSX.Element;
 
   /**
    * A class name to apply

--- a/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeSeries.tsx
+++ b/src/RadialGauge/RadialGaugeSeries/StackedRadialGaugeSeries.tsx
@@ -183,13 +183,14 @@ export const StackedRadialGaugeSeries: FC<
               outerRadius,
               innerRadius,
               colorScheme,
+              startAngle,
               scale,
               data: point
             })}
         </>
       );
     },
-    [stackedInnerArc, colorScheme, scale]
+    [stackedInnerArc, colorScheme, startAngle, scale]
   );
 
   const renderStackedGauges = useCallback(

--- a/src/RadialGauge/RadialGaugeSeries/index.ts
+++ b/src/RadialGauge/RadialGaugeSeries/index.ts
@@ -6,3 +6,4 @@ export * from './StackedRadialGaugeSeries';
 export * from './StackedRadialGaugeValueLabel';
 export * from './StackedRadialGaugeDescriptionLabel';
 export * from './RadialGaugeOuterArc';
+export * from './RadialGaugeStackedArc';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
StackedRadialGaugeSeries doesn't have ability to build stacked arcs

Issue Number: #166 


## What is the new behavior?
RadialGauge have ability to process data with nested structure (ChartDataShape) and draw stacked arcs for nested data

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://github.com/reaviz/reaviz/assets/5399389/759b4f97-6332-462f-abad-fc999b4b6873

