### PR TITLE
 Fix animation restarting on hover

### DIFF
--- a/src/AreaChart/AreaSeries/Area.tsx
+++ b/src/AreaChart/AreaSeries/Area.tsx
@@ -72,6 +72,11 @@ export interface AreaProps extends PropFunctionTypes {
    * Gradient to apply to the area.
    */
   gradient: ReactElement<GradientProps, typeof Gradient> | null;
+
+  /**
+   * Whether the chart is currently animating or not. Set internally by `AreaSeries`.
+   */
+  setIsAnimating: (isAnimating: boolean) => void;
 }
 
 export const Area: FC<Partial<AreaProps>> = ({
@@ -86,6 +91,7 @@ export const Area: FC<Partial<AreaProps>> = ({
   yScale,
   animated,
   interpolation,
+  setIsAnimating,
   ...rest
 }) => {
   const stroke = color(data, index);
@@ -192,9 +198,10 @@ export const Area: FC<Partial<AreaProps>> = ({
           enter,
           exit
         }}
+        setIsAnimating={setIsAnimating}
       />
     );
-  }, [data, enter, exit, fill, id, mask, rest, transition]);
+  }, [data, enter, exit, fill, id, mask, rest, setIsAnimating, transition]);
 
   return (
     <Fragment>

--- a/src/AreaChart/AreaSeries/Area.tsx
+++ b/src/AreaChart/AreaSeries/Area.tsx
@@ -74,9 +74,9 @@ export interface AreaProps extends PropFunctionTypes {
   gradient: ReactElement<GradientProps, typeof Gradient> | null;
 
   /**
-   * Whether the chart is currently animating or not. Set internally by `AreaSeries`.
+   * A callback function that is invoked when the animation of the chart finishes. Set internally by `AreaSeries`.
    */
-  setIsAnimating: (isAnimating: boolean) => void;
+  onAnimationFinished: () => void;
 }
 
 export const Area: FC<Partial<AreaProps>> = ({
@@ -91,7 +91,7 @@ export const Area: FC<Partial<AreaProps>> = ({
   yScale,
   animated,
   interpolation,
-  setIsAnimating,
+  onAnimationFinished,
   ...rest
 }) => {
   const stroke = color(data, index);
@@ -198,10 +198,20 @@ export const Area: FC<Partial<AreaProps>> = ({
           enter,
           exit
         }}
-        setIsAnimating={setIsAnimating}
+        onAnimationFinished={onAnimationFinished}
       />
     );
-  }, [data, enter, exit, fill, id, mask, rest, setIsAnimating, transition]);
+  }, [
+    data,
+    enter,
+    exit,
+    fill,
+    id,
+    mask,
+    rest,
+    onAnimationFinished,
+    transition
+  ]);
 
   return (
     <Fragment>

--- a/src/AreaChart/AreaSeries/AreaSeries.tsx
+++ b/src/AreaChart/AreaSeries/AreaSeries.tsx
@@ -191,7 +191,7 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
         {area && (
@@ -206,7 +206,7 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
       </Fragment>

--- a/src/AreaChart/AreaSeries/AreaSeries.tsx
+++ b/src/AreaChart/AreaSeries/AreaSeries.tsx
@@ -3,7 +3,8 @@ import React, {
   ReactElement,
   FC,
   useCallback,
-  useState
+  useState,
+  useEffect
 } from 'react';
 import { PointSeries, PointSeriesProps } from './PointSeries';
 import { Area, AreaProps } from './Area';
@@ -137,16 +138,24 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
   const [activePoint, setActivePoint] = useState<any | null>(null);
+  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
 
-  const onValueEnter = useCallback((event: TooltipAreaEvent) => {
-    setActivePoint(event.pointX);
-    setActiveValues(event.value);
-  }, []);
+  const onValueEnter = useCallback(
+    (event: TooltipAreaEvent) => {
+      if (!isAnimating) {
+        setActivePoint(event.pointX);
+        setActiveValues(event.value);
+      }
+    },
+    [isAnimating]
+  );
 
   const onValueLeave = useCallback(() => {
-    setActivePoint(undefined);
-    setActiveValues(undefined);
-  }, []);
+    if (!isAnimating) {
+      setActivePoint(undefined);
+      setActiveValues(undefined);
+    }
+  }, [isAnimating]);
 
   const isMulti =
     type === 'grouped' || type === 'stacked' || type === 'stackedNormalized';
@@ -182,6 +191,7 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
+            setIsAnimating={setIsAnimating}
           />
         )}
         {area && (
@@ -196,6 +206,7 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
+            setIsAnimating={setIsAnimating}
           />
         )}
       </Fragment>
@@ -302,6 +313,10 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
     ),
     [renderArea, renderMarkLine, renderSymbols]
   );
+
+  useEffect(() => {
+    setIsAnimating(animated);
+  }, [animated, data]);
 
   return (
     <Fragment>

--- a/src/AreaChart/AreaSeries/Line.tsx
+++ b/src/AreaChart/AreaSeries/Line.tsx
@@ -85,9 +85,9 @@ export interface LineProps extends PropFunctionTypes {
   hasArea: boolean;
 
   /**
-   * Whether the chart is currently animating or not. Set internally by `AreaSeries`.
+   * A callback function that is invoked when the animation of the chart finishes. Set internally by `AreaSeries`.
    */
-  setIsAnimating: (isAnimating: boolean) => void;
+  onAnimationFinished: () => void;
 }
 
 export const Line: FC<Partial<LineProps>> = ({
@@ -102,7 +102,7 @@ export const Line: FC<Partial<LineProps>> = ({
   xScale,
   showZeroStroke,
   interpolation,
-  setIsAnimating,
+  onAnimationFinished,
   ...rest
 }) => {
   const [pathLength, setPathLength] = useState<number | null>(null);
@@ -219,7 +219,7 @@ export const Line: FC<Partial<LineProps>> = ({
             enter,
             exit
           }}
-          setIsAnimating={setIsAnimating}
+          onAnimationFinished={onAnimationFinished}
         />
       )}
       {!hasArea && (

--- a/src/AreaChart/AreaSeries/Line.tsx
+++ b/src/AreaChart/AreaSeries/Line.tsx
@@ -83,6 +83,11 @@ export interface LineProps extends PropFunctionTypes {
    * Internal property to identify if there is a area or not.
    */
   hasArea: boolean;
+
+  /**
+   * Whether the chart is currently animating or not. Set internally by `AreaSeries`.
+   */
+  setIsAnimating: (isAnimating: boolean) => void;
 }
 
 export const Line: FC<Partial<LineProps>> = ({
@@ -97,6 +102,7 @@ export const Line: FC<Partial<LineProps>> = ({
   xScale,
   showZeroStroke,
   interpolation,
+  setIsAnimating,
   ...rest
 }) => {
   const [pathLength, setPathLength] = useState<number | null>(null);
@@ -213,6 +219,7 @@ export const Line: FC<Partial<LineProps>> = ({
             enter,
             exit
           }}
+          setIsAnimating={setIsAnimating}
         />
       )}
       {!hasArea && (

--- a/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
@@ -1,6 +1,12 @@
 import React, { ReactElement, useCallback, FC, useMemo, Fragment } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import { radialArea, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
+import {
+  radialArea,
+  curveCardinalClosed,
+  curveLinearClosed,
+  curveCardinal,
+  curveLinear
+} from 'd3-shape';
 import { RadialGradient, RadialGradientProps } from '../../common/Gradient';
 import { CloneElement } from 'rdk';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
@@ -71,6 +77,11 @@ export interface RadialAreaProps {
    * Whether the curve should be closed. Set to true by deafult
    */
   isClosedCurve: boolean;
+
+  /**
+   * Whether the chart is currently animating or not. Set internally by `RadialAreaSeries`.
+   */
+  setIsAnimating: (isAnimating: boolean) => void;
 }
 
 export const RadialArea: FC<Partial<RadialAreaProps>> = ({
@@ -86,7 +97,8 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
   innerRadius,
   interpolation,
   gradient,
-  isClosedCurve
+  isClosedCurve,
+  setIsAnimating
 }) => {
   const transition = useMemo(
     () =>
@@ -158,6 +170,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
         pointerEvents="none"
         className={className}
         fill={getFill(color)}
+        setIsAnimating={setIsAnimating}
       />
       {gradient && (
         <CloneElement<RadialGradientProps>

--- a/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
@@ -79,9 +79,9 @@ export interface RadialAreaProps {
   isClosedCurve: boolean;
 
   /**
-   * Whether the chart is currently animating or not. Set internally by `RadialAreaSeries`.
+   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialAreaSeries`.
    */
-  setIsAnimating: (isAnimating: boolean) => void;
+  onAnimationFinished: () => void;
 }
 
 export const RadialArea: FC<Partial<RadialAreaProps>> = ({
@@ -98,7 +98,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
   interpolation,
   gradient,
   isClosedCurve,
-  setIsAnimating
+  onAnimationFinished
 }) => {
   const transition = useMemo(
     () =>
@@ -170,7 +170,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
         pointerEvents="none"
         className={className}
         fill={getFill(color)}
-        setIsAnimating={setIsAnimating}
+        onAnimationFinished={onAnimationFinished}
       />
       {gradient && (
         <CloneElement<RadialGradientProps>

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -3,6 +3,7 @@ import React, {
   Fragment,
   ReactElement,
   useCallback,
+  useEffect,
   useState
 } from 'react';
 import {
@@ -141,6 +142,20 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
   isClosedCurve
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
+  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
+
+  const onValueEnter = (e) => {
+    if (!isAnimating) {
+      setActiveValues(e.value);
+    }
+  };
+
+  const onValueLeave = () => {
+    if (!isAnimating) {
+      setActiveValues(null);
+    }
+  };
+
   const isMulti = type === 'grouped';
 
   const getColorForPoint = useCallback(
@@ -175,6 +190,7 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             outerRadius={outerRadius}
             innerRadius={innerRadius}
             isClosedCurve={isClosedCurve}
+            setIsAnimating={setIsAnimating}
           />
         )}
         {line && (
@@ -189,11 +205,24 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             color={getColorForPoint}
             data={point}
             isClosedCurve={isClosedCurve}
+            setIsAnimating={setIsAnimating}
           />
         )}
       </>
     ),
-    [animated, area, getColorForPoint, id, innerRadius, interpolation, isClosedCurve, line, outerRadius, xScale, yScale]
+    [
+      animated,
+      area,
+      getColorForPoint,
+      id,
+      innerRadius,
+      interpolation,
+      isClosedCurve,
+      line,
+      outerRadius,
+      xScale,
+      yScale
+    ]
   );
 
   const renderSymbols = useCallback(
@@ -251,6 +280,9 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
     [renderArea, renderSymbols]
   );
 
+  useEffect(() => {
+    setIsAnimating(animated);
+  }, [animated, data]);
 
   return (
     <CloneElement<TooltipAreaProps>
@@ -264,8 +296,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
       innerRadius={innerRadius}
       outerRadius={outerRadius}
       color={getColorForPoint}
-      onValueEnter={(event) => setActiveValues(event.value)}
-      onValueLeave={() => setActiveValues(null)}
+      onValueEnter={onValueEnter}
+      onValueLeave={onValueLeave}
       startAngle={startAngle}
       endAngle={endAngle}
     >

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -190,7 +190,7 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             outerRadius={outerRadius}
             innerRadius={innerRadius}
             isClosedCurve={isClosedCurve}
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
         {line && (
@@ -205,7 +205,7 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             color={getColorForPoint}
             data={point}
             isClosedCurve={isClosedCurve}
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
       </>

--- a/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useMemo, FC } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import { radialLine, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
+import {
+  radialLine,
+  curveCardinalClosed,
+  curveLinearClosed,
+  curveCardinal,
+  curveLinear
+} from 'd3-shape';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
 import { MotionPath, DEFAULT_TRANSITION } from '../../common/Motion';
 
@@ -54,11 +60,16 @@ export interface RadialLineProps {
    * Internal property to identify if there is a area or not.
    */
   hasArea: boolean;
-  
+
   /**
    * Whether the curve should be closed. Set to true by deafult
    */
   isClosedCurve: boolean;
+
+  /**
+   * Whether the chart is currently animating or not. Set internally by `RadialAreaSeries`.
+   */
+  setIsAnimating: (isAnimating: boolean) => void;
 }
 
 export const RadialLine: FC<Partial<RadialLineProps>> = ({
@@ -72,7 +83,8 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
   interpolation,
   strokeWidth,
   animated,
-  isClosedCurve
+  isClosedCurve,
+  setIsAnimating
 }) => {
   const fill = color(data, index);
 
@@ -133,6 +145,7 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
       stroke={fill}
       fill="none"
       strokeWidth={strokeWidth}
+      setIsAnimating={setIsAnimating}
     />
   );
 };

--- a/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
@@ -67,9 +67,9 @@ export interface RadialLineProps {
   isClosedCurve: boolean;
 
   /**
-   * Whether the chart is currently animating or not. Set internally by `RadialAreaSeries`.
+   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialAreaSeries`.
    */
-  setIsAnimating: (isAnimating: boolean) => void;
+  onAnimationFinished: () => void;
 }
 
 export const RadialLine: FC<Partial<RadialLineProps>> = ({
@@ -84,7 +84,7 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
   strokeWidth,
   animated,
   isClosedCurve,
-  setIsAnimating
+  onAnimationFinished
 }) => {
   const fill = color(data, index);
 
@@ -145,7 +145,7 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
       stroke={fill}
       fill="none"
       strokeWidth={strokeWidth}
-      setIsAnimating={setIsAnimating}
+      onAnimationFinished={onAnimationFinished}
     />
   );
 };

--- a/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
@@ -7,7 +7,7 @@ export const MotionBar = ({
   custom,
   transition,
   arc,
-  setIsAnimating,
+  onAnimationFinished,
   ...rest
 }) => {
   const d = useMotionValue('');
@@ -31,7 +31,7 @@ export const MotionBar = ({
       //  - Must animate from prev to new position on updates ( live updates )
       if (v === 1) {
         prevPathRef.current = custom.enter;
-        setIsAnimating(false);
+        onAnimationFinished();
       }
     });
 

--- a/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
@@ -1,32 +1,26 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { motion, useMotionValue, useSpring } from 'framer-motion';
 import { interpolate } from 'd3-interpolate';
 import { DEFAULT_TRANSITION } from '../../common/Motion';
 
-export const MotionBar = ({ custom, transition, arc, ...rest }) => {
+export const MotionBar = ({
+  custom,
+  transition,
+  arc,
+  setIsAnimating,
+  ...rest
+}) => {
   const d = useMotionValue('');
-  const prevPath = useMotionValue(custom.exit);
-  const spring = useSpring(prevPath, {
+  const prevPathRef = useRef(custom.exit);
+  const spring = useSpring(useMotionValue(prevPathRef.current), {
     ...DEFAULT_TRANSITION,
     from: 0,
     to: 1
   });
 
-  const [done, setDone] = useState<boolean>(false);
-  const prevRef = useRef(custom.enter.y);
-
   useEffect(() => {
-    if (done) {
-      prevPath.set(prevRef.current);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [done]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const from = prevPath.get();
+    const from = prevPathRef.current;
     const interpolator = interpolate(from?.y, custom.enter.y);
-    setDone(false);
 
     const unsub = spring.onChange((v) => {
       d.set(arc({ ...custom.enter, y: interpolator(v) }));
@@ -36,8 +30,8 @@ export const MotionBar = ({ custom, transition, arc, ...rest }) => {
       //  - Must not animate when other props change ( tooltip hover )
       //  - Must animate from prev to new position on updates ( live updates )
       if (v === 1) {
-        prevRef.current = custom.enter;
-        setDone(true);
+        prevPathRef.current = custom.enter;
+        setIsAnimating(false);
       }
     });
 

--- a/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
@@ -114,6 +114,11 @@ export interface RadialBarProps {
    * Event for when the symbol has mouse leave.
    */
   onMouseLeave: (event) => void;
+
+  /**
+   * Whether the chart is currently animating or not. Set internally by `RadialBarSeries`.
+   */
+  setIsAnimating: (isAnimating: boolean) => void;
 }
 
 export const RadialBar: FC<Partial<RadialBarProps>> = ({
@@ -135,7 +140,8 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
   color,
   onClick,
   onMouseEnter,
-  onMouseLeave
+  onMouseLeave,
+  setIsAnimating
 }) => {
   const previousEnter = useRef<any | null>(null);
   const fill = color(data, index);
@@ -246,7 +252,16 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
         return pathFn.toString();
       }
     },
-    [barCount, curved, groupIndex, index, innerBarCount, innerRadius, xScale, yScale]
+    [
+      barCount,
+      curved,
+      groupIndex,
+      index,
+      innerBarCount,
+      innerRadius,
+      xScale,
+      yScale
+    ]
   );
 
   const renderBar = useCallback(
@@ -307,6 +322,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
                 nativeEvent: event
               })
             }
+            setIsAnimating={setIsAnimating}
           />
         </Fragment>
       );
@@ -321,6 +337,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
       onClick,
       onMouseEnter,
       onMouseLeave,
+      setIsAnimating,
       transition,
       yScale
     ]

--- a/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
@@ -116,9 +116,9 @@ export interface RadialBarProps {
   onMouseLeave: (event) => void;
 
   /**
-   * Whether the chart is currently animating or not. Set internally by `RadialBarSeries`.
+   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialBarSeries`.
    */
-  setIsAnimating: (isAnimating: boolean) => void;
+  onAnimationFinished: () => void;
 }
 
 export const RadialBar: FC<Partial<RadialBarProps>> = ({
@@ -141,7 +141,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
   onClick,
   onMouseEnter,
   onMouseLeave,
-  setIsAnimating
+  onAnimationFinished
 }) => {
   const previousEnter = useRef<any | null>(null);
   const fill = color(data, index);
@@ -322,7 +322,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
                 nativeEvent: event
               })
             }
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={onAnimationFinished}
           />
         </Fragment>
       );
@@ -337,7 +337,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
       onClick,
       onMouseEnter,
       onMouseLeave,
-      setIsAnimating,
+      onAnimationFinished,
       transition,
       yScale
     ]

--- a/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
@@ -156,7 +156,7 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
             animated={animated}
             startAngle={startAngle}
             endAngle={endAngle}
-            setIsAnimating={setIsAnimating}
+            onAnimationFinished={() => setIsAnimating(false)}
           />
         </Fragment>
       );

--- a/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
@@ -4,9 +4,14 @@ import React, {
   ReactElement,
   useState,
   useCallback,
-  useMemo
+  useMemo,
+  useEffect
 } from 'react';
-import { ChartInternalDataShape, ChartInternalNestedDataShape, ChartInternalShallowDataShape } from '../../common/data';
+import {
+  ChartInternalDataShape,
+  ChartInternalNestedDataShape,
+  ChartInternalShallowDataShape
+} from '../../common/data';
 import { RadialBar, RadialBarProps } from './RadialBar';
 import { CloneElement } from 'rdk';
 import { ColorSchemeType, getColor, schemes } from '../../common/color';
@@ -113,7 +118,20 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
   type
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
-  const isMultiSeries = useMemo(() => (type === 'grouped'), [type]);
+  const isMultiSeries = useMemo(() => type === 'grouped', [type]);
+  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
+
+  const onValueEnter = (e) => {
+    if (!isAnimating) {
+      setActiveValues(e.value);
+    }
+  };
+
+  const onValueLeave = () => {
+    if (!isAnimating) {
+      setActiveValues(null);
+    }
+  };
 
   const renderBar = useCallback(
     (point: ChartInternalShallowDataShape, innerBarCount: number, index: number, barCount: number,
@@ -138,11 +156,24 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
             animated={animated}
             startAngle={startAngle}
             endAngle={endAngle}
+            setIsAnimating={setIsAnimating}
           />
         </Fragment>
       );
     },
-    [activeValues, animated, bar, colorScheme, data, endAngle, id, innerRadius, startAngle, xScale, yScale]
+    [
+      activeValues,
+      animated,
+      bar,
+      colorScheme,
+      data,
+      endAngle,
+      id,
+      innerRadius,
+      startAngle,
+      xScale,
+      yScale
+    ]
   );
 
   const renderBarGroup = useCallback(
@@ -152,7 +183,6 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
       barCount: number,
       groupIndex?: number
     ) => {
-
       return (
         <Fragment>
           {data.map((barData, barIndex) =>
@@ -163,6 +193,10 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
     },
     [renderBar]
   );
+
+  useEffect(() => {
+    setIsAnimating(animated);
+  }, [animated, data]);
 
   return (
     <CloneElement<TooltipAreaProps>
@@ -175,8 +209,8 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
       isRadial={true}
       innerRadius={innerRadius}
       outerRadius={outerRadius}
-      onValueEnter={(event) => setActiveValues(event.value)}
-      onValueLeave={() => setActiveValues(null)}
+      onValueEnter={onValueEnter}
+      onValueLeave={onValueLeave}
       color={(point, index) => getColor({ data, point, index, colorScheme })}
       startAngle={startAngle}
       endAngle={endAngle}

--- a/src/common/Motion/MotionPath.tsx
+++ b/src/common/Motion/MotionPath.tsx
@@ -3,7 +3,12 @@ import { motion, useMotionValue, useSpring } from 'framer-motion';
 import { interpolate } from 'd3-interpolate';
 import { DEFAULT_TRANSITION } from './config';
 
-export const MotionPath = ({ custom, transition, setIsAnimating, ...rest }) => {
+export const MotionPath = ({
+  custom,
+  transition,
+  onAnimationFinished,
+  ...rest
+}) => {
   const d = useMotionValue(custom.exit.d);
   const prevPathRef = useRef(custom.exit.d);
   const spring = useSpring(useMotionValue(prevPathRef.current), {
@@ -24,7 +29,7 @@ export const MotionPath = ({ custom, transition, setIsAnimating, ...rest }) => {
       //  - Must animate from prev to new position on updates ( live updates )
       if (v === 1) {
         prevPathRef.current = custom.enter.d;
-        setIsAnimating(false);
+        onAnimationFinished();
       }
     });
 

--- a/src/common/Motion/MotionPath.tsx
+++ b/src/common/Motion/MotionPath.tsx
@@ -1,32 +1,21 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { motion, useMotionValue, useSpring } from 'framer-motion';
 import { interpolate } from 'd3-interpolate';
 import { DEFAULT_TRANSITION } from './config';
 
-export const MotionPath = ({ custom, transition, ...rest }) => {
+export const MotionPath = ({ custom, transition, setIsAnimating, ...rest }) => {
   const d = useMotionValue(custom.exit.d);
-  const prevPath = useMotionValue(custom.exit.d);
-  const spring = useSpring(prevPath, {
+  const prevPathRef = useRef(custom.exit.d);
+  const spring = useSpring(useMotionValue(prevPathRef.current), {
     ...DEFAULT_TRANSITION,
     from: 0,
     to: 1
   });
-  const [done, setDone] = useState<boolean>(false);
-  const prevRef = useRef(custom.enter.d);
 
   useEffect(() => {
-    if (done) {
-      prevPath.set(prevRef.current);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [done]);
+    const interpolator = interpolate(prevPathRef.current, custom.enter.d);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const interpolator = interpolate(prevPath.get(), custom.enter.d);
-    setDone(false);
-
-    const unsub = spring.onChange(v => {
+    const unsub = spring.onChange((v) => {
       d.set(interpolator(v));
 
       // NOTE: This is tricky logic ( Also refer to MotionBar.tsx ) ...
@@ -34,8 +23,8 @@ export const MotionPath = ({ custom, transition, ...rest }) => {
       //  - Must not animate when other props change ( tooltip hover )
       //  - Must animate from prev to new position on updates ( live updates )
       if (v === 1) {
-        prevRef.current = custom.enter.d;
-        setDone(true);
+        prevPathRef.current = custom.enter.d;
+        setIsAnimating(false);
       }
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Hovering your mouse over area charts and radial bar charts while they're in their initial animation causes the animation to restart constantly.

## What is the new behavior?
Chart animations for area charts and radial bar charts behave normally. Mark lines, points, active bars are no longer rendered during animations

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
**BEFORE**

https://github.com/reaviz/reaviz/assets/40581813/199726fb-d1a1-40f3-84cd-aaee8eb444b7


**AFTER**

https://github.com/reaviz/reaviz/assets/40581813/0ebc92d2-babf-4c11-a3ff-a696758f1433


