### PR TITLE
Fix jittering chart animations when updating data quickly

### DIFF
--- a/src/AreaChart/AreaSeries/Area.tsx
+++ b/src/AreaChart/AreaSeries/Area.tsx
@@ -72,11 +72,6 @@ export interface AreaProps extends PropFunctionTypes {
    * Gradient to apply to the area.
    */
   gradient: ReactElement<GradientProps, typeof Gradient> | null;
-
-  /**
-   * A callback function that is invoked when the animation of the chart finishes. Set internally by `AreaSeries`.
-   */
-  onAnimationFinished: () => void;
 }
 
 export const Area: FC<Partial<AreaProps>> = ({
@@ -91,7 +86,6 @@ export const Area: FC<Partial<AreaProps>> = ({
   yScale,
   animated,
   interpolation,
-  onAnimationFinished,
   ...rest
 }) => {
   const stroke = color(data, index);
@@ -198,20 +192,9 @@ export const Area: FC<Partial<AreaProps>> = ({
           enter,
           exit
         }}
-        onAnimationFinished={onAnimationFinished}
       />
     );
-  }, [
-    data,
-    enter,
-    exit,
-    fill,
-    id,
-    mask,
-    rest,
-    onAnimationFinished,
-    transition
-  ]);
+  }, [data, enter, exit, fill, id, mask, rest, transition]);
 
   return (
     <Fragment>

--- a/src/AreaChart/AreaSeries/AreaSeries.tsx
+++ b/src/AreaChart/AreaSeries/AreaSeries.tsx
@@ -3,8 +3,7 @@ import React, {
   ReactElement,
   FC,
   useCallback,
-  useState,
-  useEffect
+  useState
 } from 'react';
 import { PointSeries, PointSeriesProps } from './PointSeries';
 import { Area, AreaProps } from './Area';
@@ -138,24 +137,16 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
   const [activePoint, setActivePoint] = useState<any | null>(null);
-  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
 
-  const onValueEnter = useCallback(
-    (event: TooltipAreaEvent) => {
-      if (!isAnimating) {
-        setActivePoint(event.pointX);
-        setActiveValues(event.value);
-      }
-    },
-    [isAnimating]
-  );
+  const onValueEnter = useCallback((event: TooltipAreaEvent) => {
+    setActivePoint(event.pointX);
+    setActiveValues(event.value);
+  }, []);
 
   const onValueLeave = useCallback(() => {
-    if (!isAnimating) {
-      setActivePoint(undefined);
-      setActiveValues(undefined);
-    }
-  }, [isAnimating]);
+    setActivePoint(undefined);
+    setActiveValues(undefined);
+  }, []);
 
   const isMulti =
     type === 'grouped' || type === 'stacked' || type === 'stackedNormalized';
@@ -191,7 +182,6 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
-            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
         {area && (
@@ -206,7 +196,6 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
             animated={animated}
             interpolation={interpolation}
             color={getPointColor}
-            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
       </Fragment>
@@ -313,10 +302,6 @@ export const AreaSeries: FC<Partial<AreaSeriesProps>> = ({
     ),
     [renderArea, renderMarkLine, renderSymbols]
   );
-
-  useEffect(() => {
-    setIsAnimating(animated);
-  }, [animated, data]);
 
   return (
     <Fragment>

--- a/src/AreaChart/AreaSeries/Line.tsx
+++ b/src/AreaChart/AreaSeries/Line.tsx
@@ -83,11 +83,6 @@ export interface LineProps extends PropFunctionTypes {
    * Internal property to identify if there is a area or not.
    */
   hasArea: boolean;
-
-  /**
-   * A callback function that is invoked when the animation of the chart finishes. Set internally by `AreaSeries`.
-   */
-  onAnimationFinished: () => void;
 }
 
 export const Line: FC<Partial<LineProps>> = ({
@@ -102,7 +97,6 @@ export const Line: FC<Partial<LineProps>> = ({
   xScale,
   showZeroStroke,
   interpolation,
-  onAnimationFinished,
   ...rest
 }) => {
   const [pathLength, setPathLength] = useState<number | null>(null);
@@ -219,7 +213,6 @@ export const Line: FC<Partial<LineProps>> = ({
             enter,
             exit
           }}
-          onAnimationFinished={onAnimationFinished}
         />
       )}
       {!hasArea && (

--- a/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
@@ -1,12 +1,6 @@
 import React, { ReactElement, useCallback, FC, useMemo, Fragment } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import {
-  radialArea,
-  curveCardinalClosed,
-  curveLinearClosed,
-  curveCardinal,
-  curveLinear
-} from 'd3-shape';
+import { radialArea, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
 import { RadialGradient, RadialGradientProps } from '../../common/Gradient';
 import { CloneElement } from 'rdk';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
@@ -77,11 +71,6 @@ export interface RadialAreaProps {
    * Whether the curve should be closed. Set to true by deafult
    */
   isClosedCurve: boolean;
-
-  /**
-   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialAreaSeries`.
-   */
-  onAnimationFinished: () => void;
 }
 
 export const RadialArea: FC<Partial<RadialAreaProps>> = ({
@@ -97,8 +86,7 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
   innerRadius,
   interpolation,
   gradient,
-  isClosedCurve,
-  onAnimationFinished
+  isClosedCurve
 }) => {
   const transition = useMemo(
     () =>
@@ -170,7 +158,6 @@ export const RadialArea: FC<Partial<RadialAreaProps>> = ({
         pointerEvents="none"
         className={className}
         fill={getFill(color)}
-        onAnimationFinished={onAnimationFinished}
       />
       {gradient && (
         <CloneElement<RadialGradientProps>

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -3,7 +3,6 @@ import React, {
   Fragment,
   ReactElement,
   useCallback,
-  useEffect,
   useState
 } from 'react';
 import {
@@ -142,20 +141,6 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
   isClosedCurve
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
-  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
-
-  const onValueEnter = (e) => {
-    if (!isAnimating) {
-      setActiveValues(e.value);
-    }
-  };
-
-  const onValueLeave = () => {
-    if (!isAnimating) {
-      setActiveValues(null);
-    }
-  };
-
   const isMulti = type === 'grouped';
 
   const getColorForPoint = useCallback(
@@ -190,7 +175,6 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             outerRadius={outerRadius}
             innerRadius={innerRadius}
             isClosedCurve={isClosedCurve}
-            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
         {line && (
@@ -205,24 +189,11 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
             color={getColorForPoint}
             data={point}
             isClosedCurve={isClosedCurve}
-            onAnimationFinished={() => setIsAnimating(false)}
           />
         )}
       </>
     ),
-    [
-      animated,
-      area,
-      getColorForPoint,
-      id,
-      innerRadius,
-      interpolation,
-      isClosedCurve,
-      line,
-      outerRadius,
-      xScale,
-      yScale
-    ]
+    [animated, area, getColorForPoint, id, innerRadius, interpolation, isClosedCurve, line, outerRadius, xScale, yScale]
   );
 
   const renderSymbols = useCallback(
@@ -280,9 +251,6 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
     [renderArea, renderSymbols]
   );
 
-  useEffect(() => {
-    setIsAnimating(animated);
-  }, [animated, data]);
 
   return (
     <CloneElement<TooltipAreaProps>
@@ -296,8 +264,8 @@ export const RadialAreaSeries: FC<Partial<RadialAreaSeriesProps>> = ({
       innerRadius={innerRadius}
       outerRadius={outerRadius}
       color={getColorForPoint}
-      onValueEnter={onValueEnter}
-      onValueLeave={onValueLeave}
+      onValueEnter={(event) => setActiveValues(event.value)}
+      onValueLeave={() => setActiveValues(null)}
       startAngle={startAngle}
       endAngle={endAngle}
     >

--- a/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useMemo, FC } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
-import {
-  radialLine,
-  curveCardinalClosed,
-  curveLinearClosed,
-  curveCardinal,
-  curveLinear
-} from 'd3-shape';
+import { radialLine, curveCardinalClosed, curveLinearClosed, curveCardinal, curveLinear } from 'd3-shape';
 import { RadialInterpolationTypes } from '../../common/utils/interpolation';
 import { MotionPath, DEFAULT_TRANSITION } from '../../common/Motion';
 
@@ -60,16 +54,11 @@ export interface RadialLineProps {
    * Internal property to identify if there is a area or not.
    */
   hasArea: boolean;
-
+  
   /**
    * Whether the curve should be closed. Set to true by deafult
    */
   isClosedCurve: boolean;
-
-  /**
-   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialAreaSeries`.
-   */
-  onAnimationFinished: () => void;
 }
 
 export const RadialLine: FC<Partial<RadialLineProps>> = ({
@@ -83,8 +72,7 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
   interpolation,
   strokeWidth,
   animated,
-  isClosedCurve,
-  onAnimationFinished
+  isClosedCurve
 }) => {
   const fill = color(data, index);
 
@@ -145,7 +133,6 @@ export const RadialLine: FC<Partial<RadialLineProps>> = ({
       stroke={fill}
       fill="none"
       strokeWidth={strokeWidth}
-      onAnimationFinished={onAnimationFinished}
     />
   );
 };

--- a/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
@@ -114,11 +114,6 @@ export interface RadialBarProps {
    * Event for when the symbol has mouse leave.
    */
   onMouseLeave: (event) => void;
-
-  /**
-   * A callback function that is invoked when the animation of the chart finishes. Set internally by `RadialBarSeries`.
-   */
-  onAnimationFinished: () => void;
 }
 
 export const RadialBar: FC<Partial<RadialBarProps>> = ({
@@ -140,8 +135,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
   color,
   onClick,
   onMouseEnter,
-  onMouseLeave,
-  onAnimationFinished
+  onMouseLeave
 }) => {
   const previousEnter = useRef<any | null>(null);
   const fill = color(data, index);
@@ -252,16 +246,7 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
         return pathFn.toString();
       }
     },
-    [
-      barCount,
-      curved,
-      groupIndex,
-      index,
-      innerBarCount,
-      innerRadius,
-      xScale,
-      yScale
-    ]
+    [barCount, curved, groupIndex, index, innerBarCount, innerRadius, xScale, yScale]
   );
 
   const renderBar = useCallback(
@@ -322,7 +307,6 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
                 nativeEvent: event
               })
             }
-            onAnimationFinished={onAnimationFinished}
           />
         </Fragment>
       );
@@ -337,7 +321,6 @@ export const RadialBar: FC<Partial<RadialBarProps>> = ({
       onClick,
       onMouseEnter,
       onMouseLeave,
-      onAnimationFinished,
       transition,
       yScale
     ]

--- a/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBarSeries.tsx
@@ -4,14 +4,9 @@ import React, {
   ReactElement,
   useState,
   useCallback,
-  useMemo,
-  useEffect
+  useMemo
 } from 'react';
-import {
-  ChartInternalDataShape,
-  ChartInternalNestedDataShape,
-  ChartInternalShallowDataShape
-} from '../../common/data';
+import { ChartInternalDataShape, ChartInternalNestedDataShape, ChartInternalShallowDataShape } from '../../common/data';
 import { RadialBar, RadialBarProps } from './RadialBar';
 import { CloneElement } from 'rdk';
 import { ColorSchemeType, getColor, schemes } from '../../common/color';
@@ -118,20 +113,7 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
   type
 }) => {
   const [activeValues, setActiveValues] = useState<any | null>(null);
-  const isMultiSeries = useMemo(() => type === 'grouped', [type]);
-  const [isAnimating, setIsAnimating] = useState<boolean>(animated);
-
-  const onValueEnter = (e) => {
-    if (!isAnimating) {
-      setActiveValues(e.value);
-    }
-  };
-
-  const onValueLeave = () => {
-    if (!isAnimating) {
-      setActiveValues(null);
-    }
-  };
+  const isMultiSeries = useMemo(() => (type === 'grouped'), [type]);
 
   const renderBar = useCallback(
     (point: ChartInternalShallowDataShape, innerBarCount: number, index: number, barCount: number,
@@ -156,24 +138,11 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
             animated={animated}
             startAngle={startAngle}
             endAngle={endAngle}
-            onAnimationFinished={() => setIsAnimating(false)}
           />
         </Fragment>
       );
     },
-    [
-      activeValues,
-      animated,
-      bar,
-      colorScheme,
-      data,
-      endAngle,
-      id,
-      innerRadius,
-      startAngle,
-      xScale,
-      yScale
-    ]
+    [activeValues, animated, bar, colorScheme, data, endAngle, id, innerRadius, startAngle, xScale, yScale]
   );
 
   const renderBarGroup = useCallback(
@@ -183,6 +152,7 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
       barCount: number,
       groupIndex?: number
     ) => {
+
       return (
         <Fragment>
           {data.map((barData, barIndex) =>
@@ -193,10 +163,6 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
     },
     [renderBar]
   );
-
-  useEffect(() => {
-    setIsAnimating(animated);
-  }, [animated, data]);
 
   return (
     <CloneElement<TooltipAreaProps>
@@ -209,8 +175,8 @@ export const RadialBarSeries: FC<Partial<RadialBarSeriesProps>> = ({
       isRadial={true}
       innerRadius={innerRadius}
       outerRadius={outerRadius}
-      onValueEnter={onValueEnter}
-      onValueLeave={onValueLeave}
+      onValueEnter={(event) => setActiveValues(event.value)}
+      onValueLeave={() => setActiveValues(null)}
       color={(point, index) => getColor({ data, point, index, colorScheme })}
       startAngle={startAngle}
       endAngle={endAngle}

--- a/src/common/Motion/MotionPath.tsx
+++ b/src/common/Motion/MotionPath.tsx
@@ -17,13 +17,11 @@ export const MotionPath = ({ custom, transition, ...rest }) => {
   }, []);
 
   useEffect(() => {
-    console.log(d.get());
     let interpolator = interpolate(d.get(), custom.enter.d);
 
     spring.set(1);
 
     const unsub = spring.onChange((v) => {
-      console.log(v);
       d.set(interpolator(v));
     });
 

--- a/src/common/Motion/MotionPath.tsx
+++ b/src/common/Motion/MotionPath.tsx
@@ -1,46 +1,34 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { motion, useMotionValue, useSpring } from 'framer-motion';
 import { interpolate } from 'd3-interpolate';
 import { DEFAULT_TRANSITION } from './config';
 
 export const MotionPath = ({ custom, transition, ...rest }) => {
   const d = useMotionValue(custom.exit.d);
-  const prevPath = useMotionValue(custom.exit.d);
-  const spring = useSpring(prevPath, {
+  const spring = useSpring(0, {
     ...DEFAULT_TRANSITION,
     from: 0,
     to: 1
   });
-  const [done, setDone] = useState<boolean>(false);
-  const prevRef = useRef(custom.enter.d);
 
   useEffect(() => {
-    if (done) {
-      prevPath.set(prevRef.current);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [done]);
+    spring.set(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const interpolator = interpolate(prevPath.get(), custom.enter.d);
-    setDone(false);
+    console.log(d.get());
+    let interpolator = interpolate(d.get(), custom.enter.d);
 
-    const unsub = spring.onChange(v => {
+    spring.set(1);
+
+    const unsub = spring.onChange((v) => {
+      console.log(v);
       d.set(interpolator(v));
-
-      // NOTE: This is tricky logic ( Also refer to MotionBar.tsx ) ...
-      //  - Must animate in only once ( renders )
-      //  - Must not animate when other props change ( tooltip hover )
-      //  - Must animate from prev to new position on updates ( live updates )
-      if (v === 1) {
-        prevRef.current = custom.enter.d;
-        setDone(true);
-      }
     });
 
     return unsub;
-  });
+  }, [custom.enter.d, custom.exit.d, d, spring]);
 
   const { d: enterD, ...enterRest } = custom.enter;
   const { d: exitD, ...exitRest } = custom.exit;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When live updating data quickly, the chart data points look to be resetting to where they started at the previous animation before animating to the new position


## What is the new behavior?
Chart data points animate starting from where they were interrupted towards their new position

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**BEFORE**

https://github.com/reaviz/reaviz/assets/40581813/63aa5531-02b3-4c7e-8eb4-3942ab90dbed

**AFTER**

https://github.com/reaviz/reaviz/assets/40581813/c7d07ada-5c58-4053-be1f-fe1b9e28fadd

