### PR TITLE
Fix some bubble chart styling props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reaviz",
-  "version": "14.14.5",
+  "version": "14.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reaviz",
-      "version": "14.14.5",
+      "version": "14.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@upsetjs/venn.js": "^1.3.0",

--- a/src/BubbleChart/BubbleLabel.tsx
+++ b/src/BubbleChart/BubbleLabel.tsx
@@ -103,7 +103,6 @@ export const BubbleLabel: FC<Partial<BubbleLabelProps>> = ({
 
 BubbleLabel.defaultProps = {
   wrap: true,
-  fill: '#000',
   fontSize: 14,
   fontFamily: 'sans-serif'
 };

--- a/src/BubbleChart/BubbleSeries.tsx
+++ b/src/BubbleChart/BubbleSeries.tsx
@@ -78,14 +78,14 @@ export const BubbleSeries: FC<Partial<BubbleSeriesProps>> = ({
       >
         <CloneElement<BubbleProps>
           element={bubble}
-          id={`${id}-${index}-bubble`}
+          id={`${id}-${item.data.key}-bubble`}
           animated={animated}
           data={item}
           fill={fill}
         />
         <CloneElement<BubbleLabelProps>
           element={label}
-          id={`${id}-${index}-label`}
+          id={`${id}-${item.data.key}-label`}
           animated={animated}
           data={item}
           fill={textFill}

--- a/src/BubbleChart/BubbleSeries.tsx
+++ b/src/BubbleChart/BubbleSeries.tsx
@@ -8,6 +8,7 @@ import { CloneElement } from 'rdk';
 import invert from 'invert-color';
 import chroma from 'chroma-js';
 import { DEFAULT_TRANSITION } from '../common/Motion';
+import { identifier } from 'safe-identifier';
 
 export interface BubbleSeriesProps {
   /**
@@ -78,14 +79,14 @@ export const BubbleSeries: FC<Partial<BubbleSeriesProps>> = ({
       >
         <CloneElement<BubbleProps>
           element={bubble}
-          id={`${id}-${item.data.key}-bubble`}
+          id={identifier(`${id}-${item.data.key}-bubble`)}
           animated={animated}
           data={item}
           fill={fill}
         />
         <CloneElement<BubbleLabelProps>
           element={label}
-          id={`${id}-${item.data.key}-label`}
+          id={identifier(`${id}-${item.data.key}-label`)}
           animated={animated}
           data={item}
           fill={textFill}

--- a/src/BubbleChart/BubbleSeries.tsx
+++ b/src/BubbleChart/BubbleSeries.tsx
@@ -78,17 +78,18 @@ export const BubbleSeries: FC<Partial<BubbleSeriesProps>> = ({
       >
         <CloneElement<BubbleProps>
           element={bubble}
-          id={`${id}-bubble`}
+          id={`${id}-${index}-bubble`}
           animated={animated}
           data={item}
           fill={fill}
         />
         <CloneElement<BubbleLabelProps>
           element={label}
-          id={`${id}-label`}
+          id={`${id}-${index}-label`}
           animated={animated}
           data={item}
           fill={textFill}
+          {...label.props}
         />
       </motion.g>
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Bubble chart prop `fill` on `BubbleLabel` doesn't work
- `colorScheme` with gradients don't work

## What is the new behavior?
Bubbel Label fills and color schemes work as expected through

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
BubbleLabel fill

BEFORE
![Screenshot 2023-12-08 at 2 29 38 PM](https://github.com/reaviz/reaviz/assets/40581813/085e24d2-11ae-4b88-baa9-4d30275dcb3b)

AFTER
![Screenshot 2023-12-08 at 2 29 57 PM](https://github.com/reaviz/reaviz/assets/40581813/81c6a56e-cdcc-4dd4-b633-a315890ac3b2)

color schemes with gradients

BEFORE
![Screenshot 2023-12-08 at 2 30 19 PM](https://github.com/reaviz/reaviz/assets/40581813/1eb8c57a-27ee-441c-bdf9-3274c2200970)

AFTER
![Screenshot 2023-12-08 at 2 30 49 PM](https://github.com/reaviz/reaviz/assets/40581813/21701cc9-dc80-480d-b2b4-35c16ec58fa8)
