### PR TITLE
Add stroke and glow to Heatmaps

### DIFF
--- a/docs/charts/Heatmap.mdx
+++ b/docs/charts/Heatmap.mdx
@@ -27,6 +27,8 @@ Types supported by reaviz:
 - Heatmap
 - Calendar Heatmap
 
+`HeatmapSeries` can take a color scheme that specifies the fill, stroke, and glow for different cells
+
 ## Quick Start
 To create a Heatmap, use import the `Heatmap` and give it `data`. The chart
 will automatically configure itself with the default options exposed via `props`.
@@ -78,6 +80,25 @@ const MyChart = () => (
     data={data}
   />
 );
+```
+
+## Color Schemes
+In addition to standard color schemes, `HeatmapSeries` also accepts a color scheme that specifies the fill, stroke, and glow for different cells.
+
+```jsx
+type HeatmapColorSchemeItem = {
+  fill: string;
+  stroke: string;
+  glow: string;
+};
+
+type HeatmapColorScheme = HeatmapColorSchemeItem[];
+
+colorScheme: HeatmapColorScheme = {
+  fill: '#FFFFFF',
+  stroke: '#FFFFFF',
+  glow: '#FFFFFF'
+}
 ```
 
 ## API

--- a/docs/charts/Heatmap.mdx
+++ b/docs/charts/Heatmap.mdx
@@ -27,8 +27,6 @@ Types supported by reaviz:
 - Heatmap
 - Calendar Heatmap
 
-`HeatmapSeries` can take a color scheme that specifies the fill, stroke, and glow for different cells
-
 ## Quick Start
 To create a Heatmap, use import the `Heatmap` and give it `data`. The chart
 will automatically configure itself with the default options exposed via `props`.
@@ -80,25 +78,6 @@ const MyChart = () => (
     data={data}
   />
 );
-```
-
-## Color Schemes
-In addition to standard color schemes, `HeatmapSeries` also accepts a color scheme that specifies the fill, stroke, and glow for different cells.
-
-```jsx
-type HeatmapColorSchemeItem = {
-  fill: string;
-  stroke: string;
-  glow: string;
-};
-
-type HeatmapColorScheme = HeatmapColorSchemeItem[];
-
-colorScheme: HeatmapColorScheme = {
-  fill: '#FFFFFF',
-  stroke: '#FFFFFF',
-  glow: '#FFFFFF'
-}
 ```
 
 ## API

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -68,6 +68,16 @@ export type HeatmapCellProps = {
   fill: string;
 
   /**
+   * Stroke color set by `HeatmapSeries`.
+   */
+  stroke: string;
+
+  /**
+   * CSS filter styling set by `HeatmapSeries`. Used for glow effect.
+   */
+  filter: string;
+
+  /**
    * Data object set by `Heatmap`.
    */
   data: ChartInternalShallowDataShape;
@@ -127,6 +137,8 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
   cellIndex,
   cellCount,
   fill,
+  stroke,
+  filter,
   x,
   y,
   style,
@@ -185,7 +197,8 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
 
   const extras = constructFunctionProps({ style, className }, data);
   const isTransparent = fill === 'transparent';
-  const stroke = active && !isTransparent ? chroma(fill).brighten(1) : fill;
+  const appliedStroke =
+    active && !isTransparent ? chroma(stroke).brighten(1) : stroke;
 
   return (
     <Fragment>
@@ -193,12 +206,12 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
         <motion.rect
           {...rest}
           fill={fill}
-          stroke={stroke}
+          stroke={appliedStroke}
           x={x}
           y={y}
           rx={rx}
           ry={ry}
-          style={{ ...extras.style, cursor }}
+          style={{ ...extras.style, cursor, filter }}
           className={classNames(css.cell, extras.className)}
           initial={{
             opacity: 0

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -198,7 +198,9 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
   const extras = constructFunctionProps({ style, className }, data);
   const isTransparent = fill === 'transparent';
   const appliedStroke =
-    active && !isTransparent ? chroma(stroke).brighten(1) : stroke;
+    active && !isTransparent
+      ? chroma(stroke || fill).brighten(1)
+      : stroke || fill;
 
   return (
     <Fragment>
@@ -211,7 +213,7 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
           y={y}
           rx={rx}
           ry={ry}
-          style={{ ...extras.style, cursor, filter }}
+          style={{ ...extras.style, cursor }}
           className={classNames(css.cell, extras.className)}
           initial={{
             opacity: 0

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -73,11 +73,6 @@ export type HeatmapCellProps = {
   stroke: string;
 
   /**
-   * CSS filter styling set by `HeatmapSeries`. Used for glow effect.
-   */
-  filter: string;
-
-  /**
    * Data object set by `Heatmap`.
    */
   data: ChartInternalShallowDataShape;
@@ -138,7 +133,6 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
   cellCount,
   fill,
   stroke,
-  filter,
   x,
   y,
   style,

--- a/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
@@ -85,7 +85,10 @@ export const HeatmapSeries: FC<Partial<HeatmapSeriesProps>> = ({
   }) => {
     const x = xScale(row.key);
     const y = yScale(cell.x);
-    const colorSchemeStyles = getColorSchemeStyles(cell.value, valueScales);
+    const { fill, stroke, filter } = getColorSchemeStyles(
+      cell.value,
+      valueScales
+    );
 
     return (
       <CloneElement<HeatmapCellProps>
@@ -96,12 +99,12 @@ export const HeatmapSeries: FC<Partial<HeatmapSeriesProps>> = ({
         cellCount={cellCount}
         x={x}
         y={y}
-        fill={colorSchemeStyles?.fill}
-        stroke={colorSchemeStyles?.stroke}
+        fill={fill}
+        stroke={stroke}
         width={width}
         height={height}
         data={cell}
-        style={{ ...colorSchemeStyles }}
+        style={{ filter }}
       />
     );
   };

--- a/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
@@ -4,6 +4,7 @@ import { CloneElement } from 'rdk';
 import { ColorSchemeType } from '../../common/color';
 import { ChartInternalNestedDataShape } from '../../common/data';
 import {
+  ColorSchemeStyleArray,
   createColorSchemeValueScales,
   getColorSchemeStyles
 } from '../../common/color/helper';
@@ -37,7 +38,7 @@ export interface HeatmapSeriesProps {
   /**
    * Color scheme for the chart.
    */
-  colorScheme: ColorSchemeType;
+  colorScheme: ColorSchemeType | ColorSchemeStyleArray;
 
   /**
    * Color for the empty cell of the chart.

--- a/src/common/color/helper.ts
+++ b/src/common/color/helper.ts
@@ -1,7 +1,6 @@
 import { scaleOrdinal, scaleQuantile } from 'd3-scale';
-import { maxIndex } from 'd3-array';
+import { maxIndex, extent } from 'd3-array';
 import { schemes } from './schemes';
-import { extent } from 'd3-array';
 import { uniqueBy } from '../utils';
 
 export type ColorSchemeType =
@@ -88,6 +87,15 @@ export const getColor = (props: Partial<ColorHelperProps>) => {
   }
 };
 
+/**
+ * This function creates a value scale that maps data points to colors or CSS styles.
+ *
+ * @param {Array} data - The data used to create the scale.
+ * @param {ColorSchemeType} colorScheme - The color scheme used to generate the scale. This can be an array of colors or an array of css styles objects.
+ * @param {string} emptyColor - The color used for data points with no value.
+ *
+ * @returns {ColorSchemeValueScale} A function that takes a data point and returns a color or CSS style based on the data point's value.
+ */
 const getValueScale = (
   data,
   colorScheme: ColorSchemeType,
@@ -117,6 +125,14 @@ const getValueScale = (
   };
 };
 
+/**
+ * This function generates a style object for a given data point based on a map of value scales.
+ *
+ * @param {any} point - The data point for which to generate the style object.
+ * @param {Map<string, ColorSchemeValueScale>} valueScales - A map where each key is a property name and each value is a function that takes a data point and returns a color or CSS style.
+ *
+ * @returns {Partial<CSSStyleDeclaration>} A style object where each key is a property name and each value is a color or CSS style based on the value of the data point for that property.
+ */
 export const getColorSchemeStyles = (
   point,
   valueScales: Map<string, ColorSchemeValueScale>
@@ -125,6 +141,14 @@ export const getColorSchemeStyles = (
     return { ...acc, [key]: valueScale(point) };
   }, {});
 
+/**
+ * This function retrieves a color scheme for a specific property from a given color scheme.
+ *
+ * @param {ColorSchemeType} colorScheme - The color scheme used to generate the scale. This can be an array of colors or an array of objects where each object maps a property to a color.
+ * @param {string} colorSchemeProperty - The property for which to retrieve the color scheme.
+ *
+ * @returns {ColorSchemeType} A color scheme for the specified property.
+ */
 const getColorSchemeForProperty = (
   colorScheme: ColorSchemeType,
   colorSchemeProperty: string
@@ -156,7 +180,6 @@ const getColorSchemeForProperty = (
  * @returns {Map<string, ColorSchemeValueScale>} A map where each key is a property name and each value is a function that takes a data point and returns a value for the property.
  *
  * If the color scheme is an array of strings, they will be treated as fill values.
- *
  */
 export const createColorSchemeValueScales = (
   data,
@@ -164,8 +187,6 @@ export const createColorSchemeValueScales = (
   emptyColor: string
 ): Map<string, ColorSchemeValueScale> => {
   const valueScales = new Map<string, ColorSchemeValueScale>();
-
-  valueScales.set('fill', getValueScale(data, colorScheme, emptyColor));
 
   const isColorSchemeObjectArray =
     Array.isArray(colorScheme) && typeof colorScheme[0] === 'object';
@@ -183,6 +204,8 @@ export const createColorSchemeValueScales = (
       );
       valueScales.set(key, valueScale);
     });
+  } else {
+    valueScales.set('fill', getValueScale(data, colorScheme, emptyColor));
   }
 
   return valueScales;

--- a/src/common/color/helper.ts
+++ b/src/common/color/helper.ts
@@ -1,9 +1,12 @@
-import { scaleOrdinal } from 'd3-scale';
+import { scaleOrdinal, scaleQuantile } from 'd3-scale';
 import { maxIndex } from 'd3-array';
 import { schemes } from './schemes';
+import { extent } from 'd3-array';
+import { uniqueBy } from '../utils';
 
 export type ColorSchemeType =
   | ((data, index: number, active?: any[]) => string)
+  | Partial<CSSStyleDeclaration>[]
   | string[]
   | string;
 
@@ -19,6 +22,8 @@ type ColorHelperProps = {
   attribute?: string;
   isMultiSeries?: boolean;
 };
+
+type ColorSchemeValueScale = (point: any) => string;
 
 /**
  * Given a point, get the key attributes for it.
@@ -81,4 +86,104 @@ export const getColor = (props: Partial<ColorHelperProps>) => {
   } else {
     return colorScheme;
   }
+};
+
+const getValueScale = (
+  data,
+  colorScheme: ColorSchemeType,
+  emptyColor: string
+): ColorSchemeValueScale => {
+  const valueDomain = extent(
+    uniqueBy(
+      data,
+      (d) => d.data,
+      (d) => d.value
+    )
+  );
+
+  return (point) => {
+    // For 0 values, lets show a placeholder fill
+    if (point === undefined || point === null) {
+      return emptyColor;
+    }
+
+    // Note: this can return css style values, not just colors
+    return getColor({
+      scale: scaleQuantile,
+      domain: valueDomain,
+      key: point,
+      colorScheme
+    });
+  };
+};
+
+export const getColorSchemeStyles = (
+  point,
+  valueScales: Map<string, ColorSchemeValueScale>
+): Partial<CSSStyleDeclaration> =>
+  Array.from(valueScales).reduce((acc, [key, valueScale]) => {
+    return { ...acc, [key]: valueScale(point) };
+  }, {});
+
+const getColorSchemeForProperty = (
+  colorScheme: ColorSchemeType,
+  colorSchemeProperty: string
+): ColorSchemeType => {
+  if (!Array.isArray(colorScheme)) {
+    return colorScheme;
+  }
+
+  const newColorScheme = colorScheme.map(
+    (schemeItem: string | Partial<CSSStyleDeclaration>) => {
+      if (typeof schemeItem === 'object') {
+        return schemeItem?.[colorSchemeProperty];
+      }
+
+      return schemeItem;
+    }
+  );
+  return newColorScheme;
+};
+
+/**
+ * This function creates a map of value scales for different properties based on a provided color scheme.
+ * Each value scale is a function that takes a data point and returns a css style value based on that point.
+ *
+ * @param {Array} data - The data used to create the scales.
+ * @param {ColorSchemeType} colorScheme - The color scheme used to generate the scales. This can be an array of colors or an array of objects where each object contains a set of css styles.
+ * @param {string} emptyColor - The color used for data points with no value.
+ *
+ * @returns {Map<string, ColorSchemeValueScale>} A map where each key is a property name and each value is a function that takes a data point and returns a value for the property.
+ *
+ * If the color scheme is an array of strings, they will be treated as fill values.
+ *
+ */
+export const createColorSchemeValueScales = (
+  data,
+  colorScheme: ColorSchemeType,
+  emptyColor: string
+): Map<string, ColorSchemeValueScale> => {
+  const valueScales = new Map<string, ColorSchemeValueScale>();
+
+  valueScales.set('fill', getValueScale(data, colorScheme, emptyColor));
+
+  const isColorSchemeObjectArray =
+    Array.isArray(colorScheme) && typeof colorScheme[0] === 'object';
+
+  if (isColorSchemeObjectArray) {
+    const colorSchemeProperties = isColorSchemeObjectArray
+      ? [...new Set(colorScheme.flatMap(Object.keys))]
+      : [];
+
+    colorSchemeProperties.forEach((key) => {
+      const valueScale = getValueScale(
+        data,
+        getColorSchemeForProperty(colorScheme, key),
+        emptyColor
+      );
+      valueScales.set(key, valueScale);
+    });
+  }
+
+  return valueScales;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There's limited styling options for heatmaps

## What is the new behavior?
You can now specify a `fill`, `stroke`, and `filter` in your heatmap color scheme

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This adds a new optional shape for `colorScheme` that can be used in `HeatmapSeries`. 

e.g.
```
colorScheme: { fill: string, stroke: string, filter: string}
```

This is a color scheme type that could be useful in other graphs where you want to include more properties in your color scheme than just the fill

![image](https://github.com/reaviz/reaviz/assets/40581813/112918bd-e67f-44c7-81b7-de82fc8094d0)
