### PR TITLE
UNF-98, UNF-97: Focus state for main SVG element & Aria Labels for Chart Elements

### DIFF
--- a/src/BarChart/BarSeries/Bar.tsx
+++ b/src/BarChart/BarSeries/Bar.tsx
@@ -576,6 +576,7 @@ export const Bar: FC<Partial<BarProps>> = ({
             onMouseLeave={onMouseLeaveInternal}
             onClick={onMouseClick}
             onMouseMove={onMouseMove}
+            aria-label={JSON.stringify(tooltipData)}
           />
         </g>
       );
@@ -596,7 +597,8 @@ export const Bar: FC<Partial<BarProps>> = ({
       onMouseMove,
       rx,
       ry,
-      style
+      style,
+      tooltipData
     ]
   );
 

--- a/src/BarList/BarListSeries.tsx
+++ b/src/BarList/BarListSeries.tsx
@@ -154,7 +154,7 @@ export const BarListSeries: FC<Partial<BarListSeriesProps>> = ({
             onMouseLeave={() => onItemMouseLeave?.(d)}
             onClick={() => onItemClick?.(d)}
           >
-            <label className={classNames(css.label, labelClassName)}>
+            <label title={label} className={classNames(css.label, labelClassName)}>
               {label}
             </label>
             {renderBar(d, i)}

--- a/src/BubbleChart/Bubble.tsx
+++ b/src/BubbleChart/Bubble.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactElement, useRef, useState } from 'react';
+import React, { FC, Fragment, ReactElement, useMemo, useRef, useState } from 'react';
 import { HierarchyCircularNode } from 'd3-hierarchy';
 import { ChartTooltip, ChartTooltipProps } from '../common/Tooltip';
 import { CloneElement } from 'rdk';
@@ -102,6 +102,8 @@ export const Bubble: FC<Partial<BubbleProps>> = ({
       ? `url(#mask-pattern-${id})`
       : fill;
 
+  const tooltipData = useMemo(() => ({ y: data.data.data, x: data.data.key }), [data]) ;
+
   return (
     <Fragment>
       <motion.circle
@@ -123,6 +125,7 @@ export const Bubble: FC<Partial<BubbleProps>> = ({
         onClick={onClick}
         onPointerOver={pointerOver}
         onPointerOut={pointerOut}
+        aria-label={JSON.stringify(tooltipData)}
       />
       {mask && (
         <Fragment>
@@ -146,7 +149,7 @@ export const Bubble: FC<Partial<BubbleProps>> = ({
           element={tooltip}
           visible={!!internalActive}
           reference={bubbleRef}
-          value={{ y: data.data.data, x: data.data.key }}
+          value={tooltipData}
         />
       )}
     </Fragment>

--- a/src/FunnelChart/FunnelSeries/FunnelArc.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelArc.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from 'react';
+import React, { FC, ReactElement, useMemo } from 'react';
 import { ChartShallowDataShape } from '../../common/data';
 import { area } from 'd3-shape';
 import { InterpolationTypes, interpolate } from '../../common/utils';
@@ -119,6 +119,8 @@ export const FunnelArc: FC<Partial<FunnelArcProps>> = ({
   const [height] = yScale.range();
   const [_, width] = xScale.range();
 
+  const ariaLabelData = useMemo(() => (data?.map(row => (`${row?.key}: ${row?.data}`)).join(', ')), [data]);
+
   return (
     <CloneElement<TooltipAreaProps>
       element={tooltip}
@@ -145,6 +147,7 @@ export const FunnelArc: FC<Partial<FunnelArcProps>> = ({
       <g
         pointerEvents={tooltip ? 'none' : 'auto'}
         style={generateGlowStyles({ glow })}
+        aria-label={ariaLabelData}
       >
         <motion.path
           d={areaGenerator(internalData as any[])}

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -222,6 +222,7 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
           onPointerOver={pointerOver}
           onPointerOut={pointerOut}
           onClick={onMouseClick}
+          aria-label={JSON.stringify(tooltipData)}
         />
       </g>
       {tooltip && !(tooltip.props as any).disabled && !isTransparent && (

--- a/src/Map/MapMarker.tsx
+++ b/src/Map/MapMarker.tsx
@@ -53,6 +53,7 @@ export const MapMarker: FC<Partial<MapMarkerProps>> = ({
         onMouseEnter={() => setActive(true)}
         onMouseLeave={() => setActive(false)}
         onClick={onClick}
+        aria-label={typeof tooltip === 'string' ? tooltip: 'map marker'}
       />
       {tooltip && (
         <Tooltip

--- a/src/PieChart/PieArcSeries/PieArc.tsx
+++ b/src/PieChart/PieArcSeries/PieArc.tsx
@@ -133,8 +133,10 @@ export const PieArc: FC<PieArcProps> = ({
     [gradient, id, color]
   );
 
+  const tooltipData = useMemo(() => ({ y: data.data.data, x: data.data.key }), [data]);
+
   return (
-    <g ref={arcRef}>
+    <g ref={arcRef} aria-label={JSON.stringify(tooltipData)}>
       <motion.path
         role="graphics-symbol"
         d={d}
@@ -164,7 +166,7 @@ export const PieArc: FC<PieArcProps> = ({
           element={tooltip}
           visible={!!active}
           reference={arcRef}
-          value={{ y: data.data.data, x: data.data.key }}
+          value={tooltipData}
         />
       )}
     </g>

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
@@ -4,7 +4,8 @@ import React, {
   Fragment,
   ReactElement,
   FC,
-  useState
+  useState,
+  useMemo
 } from 'react';
 import { ChartInternalShallowDataShape } from '../../common/data';
 import { radialLine } from 'd3-shape';
@@ -184,6 +185,8 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
   const [yStart] = yScale.domain();
   const exitTransform = getTranslate({ ...data, y: yStart });
 
+  const ariaLabelData = useMemo(() => (JSON.stringify(data)), [data]);
+
   return (
     <Fragment>
       <motion.g
@@ -198,6 +201,7 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
         className={classNames(className, {
           [css.inactive]: !active
         })}
+        aria-label={ariaLabelData}
       >
         {symbol && symbol(data)}
         {!symbol && <circle r={sizeVal} fill={fill} />}

--- a/src/Sankey/SankeyLink/SankeyLink.tsx
+++ b/src/Sankey/SankeyLink/SankeyLink.tsx
@@ -170,6 +170,8 @@ export const SankeyLink: FC<Partial<SankeyLinkProps>> = ({
     }
   });
 
+  const ariaLabelData = useMemo(() => (`${(source as NodeExtra).title} → ${(target as NodeExtra).title}: ${formatValue(value)}`), [source, target, value]);
+
   return (
     <Fragment>
       {gradient && (
@@ -199,6 +201,7 @@ export const SankeyLink: FC<Partial<SankeyLinkProps>> = ({
           onClick={onClick}
           onPointerOver={pointerOver}
           onPointerOut={pointerOut}
+          aria-label={ariaLabelData}
         />
       </g>
       {!tooltip?.props?.disabled && (

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -4,7 +4,8 @@ import React, {
   useCallback,
   FC,
   useState,
-  useRef
+  useRef,
+  useMemo
 } from 'react';
 import classNames from 'classnames';
 import { motion } from 'framer-motion';
@@ -179,9 +180,11 @@ export const SankeyNode: FC<Partial<SankeyNodeProps>> = ({
     }
   });
 
+  const ariaLabelData = useMemo(() => (`${title}: ${formatValue(value as ChartInternalDataTypes)}`), [title, value]);
+
   return (
     <Fragment>
-      <motion.g ref={rectRef}>
+      <motion.g ref={rectRef} aria-label={ariaLabelData}>
         <motion.rect
           key={`sankey-node-${x0}-${x1}-${y0}-${y1}-${index}`}
           className={classNames(css.node, className)}

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
@@ -198,6 +198,8 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = ({
 
   const key = `symbol-${id}-${identifier(`${data!.id}`)}`;
 
+  const ariaLabelData = useMemo(() => (JSON.stringify(data)), [data]);
+
   return (
     <Fragment>
       <g
@@ -214,6 +216,7 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = ({
           onMouseLeave(data!);
         }}
         onClick={() => onClick(data!)}
+        aria-label={ariaLabelData}
       >
         {symbol ? (
           <motion.g

--- a/src/TreeMap/TreeMapRect.tsx
+++ b/src/TreeMap/TreeMapRect.tsx
@@ -96,6 +96,8 @@ export const TreeMapRect: FC<Partial<TreeMapRectProps>> = ({
     return getKey(data).join(' -> ');
   }, [data]);
 
+  const tooltipData = useMemo(() => ({ y: data.value, x: tooltipLabel }), [data, tooltipLabel]);
+
   return (
     <Fragment>
       <motion.rect
@@ -117,13 +119,14 @@ export const TreeMapRect: FC<Partial<TreeMapRectProps>> = ({
         }}
         onPointerOver={pointerOver}
         onPointerOut={pointerOut}
+        aria-label={JSON.stringify(tooltipData)}
       />
       {tooltip && !tooltip.props.disabled && (
         <CloneElement<ChartTooltipProps>
           element={tooltip}
           visible={!!internalActive}
           reference={rectRef}
-          value={{ y: data.value, x: tooltipLabel }}
+          value={tooltipData}
         />
       )}
     </Fragment>

--- a/src/VennDiagram/VennArc.tsx
+++ b/src/VennDiagram/VennArc.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, ReactElement, useState, Fragment } from 'react';
+import React, { FC, useRef, ReactElement, useState, Fragment, useMemo } from 'react';
 import { IVennLayout } from '@upsetjs/venn.js';
 import { ChartTooltip, ChartTooltipProps } from '../common/Tooltip';
 import { CloneElement } from 'rdk';
@@ -172,6 +172,8 @@ export const VennArc: FC<Partial<VennArcProps>> = ({
     }
   });
 
+  const tooltipData = useMemo(() => ({ y: data.data.size, x: data.data?.sets?.join(' | ') }), [data]);
+
   return (
     <g
       title={data.data.key}
@@ -185,6 +187,7 @@ export const VennArc: FC<Partial<VennArcProps>> = ({
           });
         }
       }}
+      aria-label={JSON.stringify(tooltipData)}
     >
       <motion.path
         ref={arcRef}
@@ -226,7 +229,7 @@ export const VennArc: FC<Partial<VennArcProps>> = ({
           element={tooltip}
           visible={!!internalActive}
           reference={arcRef}
-          value={{ y: data.data.size, x: data.data?.sets?.join(' | ') }}
+          value={tooltipData}
         />
       )}
     </g>

--- a/src/common/containers/ChartContainer.tsx
+++ b/src/common/containers/ChartContainer.tsx
@@ -189,6 +189,7 @@ export const ChartContainer: FC<ChartContainerProps> = ({
             height={height}
             className={className}
             style={style}
+            tabIndex={0}
           >
             <g transform={`translate(${translateX}, ${translateY})`}>
               {children(childProps)}


### PR DESCRIPTION
This PR:-

- Makes the main SVG element focusable
<img width="482" alt="Screenshot 2023-12-26 at 10 23 54 PM" src="https://github.com/reaviz/reaviz/assets/33908100/b70a5301-69b2-4eaa-8152-19455b38f354">

- Adds the aria-label based on the tooltip to the chart elements. A few examples:-

<img width="1081" alt="Screenshot 2023-12-26 at 10 20 48 PM" src="https://github.com/reaviz/reaviz/assets/33908100/f582b485-5df9-4087-b1a2-405d0d0374b4">

<img width="1093" alt="Screenshot 2023-12-26 at 10 21 37 PM" src="https://github.com/reaviz/reaviz/assets/33908100/ec215e0f-26d3-4001-b7b2-39570ea6d292">

<img width="1093" alt="Screenshot 2023-12-26 at 10 22 18 PM" src="https://github.com/reaviz/reaviz/assets/33908100/58a5b3c0-a092-46a3-8417-d4c5ee69a97a">

