### PR TITLE
UNF-100: Line/Area/Radial - hide points instead of removing from DOM - enable tabbing

### DIFF
--- a/src/AreaChart/AreaChartCircle.story.tsx
+++ b/src/AreaChart/AreaChartCircle.story.tsx
@@ -41,7 +41,7 @@ export const Off = () => (
       width={350}
       height={250}
       data={singleDateData}
-      series={<AreaSeries symbols={null} />}
+      series={<AreaSeries symbols={<PointSeries show={false} />} />}
     />
   );
 

--- a/src/LineChart/LineChartCircle.story.tsx
+++ b/src/LineChart/LineChartCircle.story.tsx
@@ -28,7 +28,7 @@ export const Off = () => (
     width={350}
     height={250}
     data={singleDateData}
-    series={<LineSeries symbols={null} />}
+    series={<LineSeries symbols={<PointSeries show={false} />} />}
   />
 );
 

--- a/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/MotionBar.tsx
@@ -45,6 +45,7 @@ export const MotionBar = ({ custom, transition, arc, ...rest }) => {
       animate={enterRest}
       transition={transition}
       d={transition.type !== false ? d : enterD}
+      tabIndex={0}
     />
   );
 };

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.module.css
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.module.css
@@ -2,3 +2,7 @@
   opacity: 0.4;
   transition: opacity 200ms ease-in-out;
 }
+
+.hidden {
+  opacity: 0;
+}

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.module.css.d.ts
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.module.css.d.ts
@@ -1,6 +1,7 @@
 export const inactive: string;
 interface Namespace {
   inactive: string;
+  hidden: string;
 }
 declare const radialScatterPointModule: Namespace;
 export default radialScatterPointModule;

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
@@ -189,7 +189,7 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
 
   const ariaLabelData = useMemo(() => getAriaLabel(data), [data]);
 
-  const isVisible = visible?.(data, index);
+  const isVisible = visible ? visible?.(data, index) : active;  
 
   return (
     <Fragment>

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
@@ -117,6 +117,7 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
   xScale,
   animated,
   className,
+  visible,
   ...rest
 }) => {
   const ref = useRef<any>(null);
@@ -188,6 +189,7 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
 
   const ariaLabelData = useMemo(() => getAriaLabel(data), [data]);
 
+  const isVisible = visible?.(data, index);
 
   return (
     <Fragment>
@@ -201,7 +203,8 @@ export const RadialScatterPoint: FC<Partial<RadialScatterPointProps>> = ({
         onMouseLeave={onMouseLeave}
         onClick={onClick}
         className={classNames(className, {
-          [css.inactive]: !active
+          [css.inactive]: !active,
+          [css.hidden]: !isVisible,
         })}
         tabIndex={0}
         aria-label={ariaLabelData}

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterSeries.tsx
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterSeries.tsx
@@ -86,11 +86,6 @@ export const RadialScatterSeries: FC<Partial<RadialScatterSeriesProps>> = ({
     const active =
       !(internalActiveIds && internalActiveIds.length) || internalActiveIds.includes(dataId);
 
-    const visible = point.props.visible;
-    if (visible && !visible(d, index)) {
-      return <Fragment key={key} />;
-    }
-
     return (
       <CloneElement<RadialScatterPointProps>
         element={point}

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.module.css
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.module.css
@@ -1,3 +1,7 @@
 .inactive {
   opacity: 0.2;
 }
+
+.hidden {
+  opacity: 0;
+}

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.module.css.d.ts
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.module.css.d.ts
@@ -1,6 +1,7 @@
 export const inactive: string;
 interface Namespace {
   inactive: string;
+  hidden: string;
 }
 declare const scatterPointModule: Namespace;
 export default scatterPointModule;

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
@@ -201,7 +201,7 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = ({
   const key = `symbol-${id}-${identifier(`${data!.id}`)}`;
   const ariaLabelData = useMemo(() => getAriaLabel(data), [data]);
 
-  const isVisible = visible?.(data, index);
+  const isVisible = visible ? visible?.(data, index) : active;
 
   return (
     <Fragment>

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
@@ -133,6 +133,7 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = ({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  visible,
   ...rest
 }) => {
   const rectRef = useRef<any | null>(null);
@@ -200,12 +201,15 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = ({
   const key = `symbol-${id}-${identifier(`${data!.id}`)}`;
   const ariaLabelData = useMemo(() => getAriaLabel(data), [data]);
 
+  const isVisible = visible?.(data, index);
+
   return (
     <Fragment>
       <g
         ref={rectRef}
         className={classNames({
-          [css.inactive]: !active
+          [css.inactive]: !active,
+          [css.hidden]: !isVisible,
         })}
         onMouseEnter={() => {
           setTooltipVisible(true);

--- a/src/ScatterPlot/ScatterSeries/ScatterSeries.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterSeries.tsx
@@ -82,11 +82,6 @@ export const ScatterSeries: FC<Partial<ScatterSeriesProps>> = ({
       const active =
         !(activeIds && activeIds.length) || activeIds.includes(pointId);
 
-      const visible = point.props.visible;
-      if (visible && !visible(pointData, index)) {
-        return <Fragment key={key} />;
-      }
-
       return (
         <CloneElement<ScatterPointProps>
           element={point}


### PR DESCRIPTION
This PR enables tabbing through the data points even when the symbols are not visible as we now render the points and set their opacity to 0 instead of removing them from the DOM.

https://github.com/reaviz/reaviz/assets/33908100/c5c0e979-959a-4247-aa7e-890078581f0c

