### PR TITLE
Fix bar chart tooltip hover accuracy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reaviz",
-  "version": "15.9.0",
+  "version": "15.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reaviz",
-      "version": "15.9.0",
+      "version": "15.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@upsetjs/venn.js": "^1.3.0",

--- a/src/BarChart/BarSeries/BarSeries.tsx
+++ b/src/BarChart/BarSeries/BarSeries.tsx
@@ -338,6 +338,7 @@ export const BarSeries: FC<Partial<BarSeriesProps>> = ({
       color={getBarColor}
       onValueEnter={onValueEnter}
       onValueLeave={onValueLeave}
+      isContinous={false}
     >
       {isMultiSeries &&
         (data as ChartInternalNestedDataShape[]).map((groupData, index) => (

--- a/src/FunnelChart/FunnelSeries/FunnelSeries.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelSeries.tsx
@@ -3,7 +3,11 @@ import { FunnelArc } from './FunnelArc';
 import { CloneElement } from 'rdk';
 import { FunnelArcProps } from './FunnelArc';
 import { FunnelAxis, FunnelAxisProps } from './FunnelAxis';
-import { ChartShallowDataShape, getClosestPoint, getPositionForTarget } from '../../common';
+import {
+  ChartShallowDataShape,
+  getClosestContinousScalePoint,
+  getPositionForTarget
+} from '../../common';
 import { ClickEvent } from '../../common/types';
 import { scaleLinear } from 'd3-scale';
 import { max } from 'd3-array';
@@ -94,8 +98,7 @@ export const FunnelSeries: React.FC<Partial<FunnelSeriesProps>> = ({
         datas: [
           { data, ...getScales(height, width) },
           { data, ...getScales(height - offset, width) },
-          { data, ...getScales(height - (offset * 2), width) }
-        ]
+          { data, ...getScales(height - (offset * 2), width) }        ]
       };
     } else {
       return {
@@ -112,7 +115,9 @@ export const FunnelSeries: React.FC<Partial<FunnelSeriesProps>> = ({
       const { xScale, data } = datas[0];
       const { clientX, clientY, target } = e;
       const position = getPositionForTarget({ target, clientX, clientY });
-      const value = getClosestPoint(position.x, xScale, data, 'i');
+      const value = getClosestContinousScalePoint(position.x, xScale, data, {
+        attr: 'i'
+      });
 
       onSegmentClick({
         value: { key: value.key, data: value.data },
@@ -151,4 +156,3 @@ FunnelSeries.defaultProps = {
   arc: <FunnelArc />,
   axis: <FunnelAxis />
 };
-

--- a/src/FunnelChart/FunnelSeries/FunnelSeries.tsx
+++ b/src/FunnelChart/FunnelSeries/FunnelSeries.tsx
@@ -56,35 +56,33 @@ export const FunnelSeries: React.FC<Partial<FunnelSeriesProps>> = ({
   axis,
   height,
   width,
-  onSegmentClick,
+  onSegmentClick
 }) => {
   // Calculate the funnel data on mount and when data changes
-  const getScales = useCallback((height: number, width: number) => {
-    const yScale = scaleLinear()
-      .domain([
-        -max(data, ({ data }) => data),
-        max(data, ({ data }) => data)
-      ])
-      .nice()
-      .range([height, 0]);
+  const getScales = useCallback(
+    (height: number, width: number) => {
+      const yScale = scaleLinear()
+        .domain([-max(data, ({ data }) => data), max(data, ({ data }) => data)])
+        .nice()
+        .range([height, 0]);
 
-    const xScale = scaleLinear()
-      .domain([0, data.length])
-      .range([0, width]);
+      const xScale = scaleLinear().domain([0, data.length]).range([0, width]);
 
-    const transformedData = data.map((d, i) => ({
-      ...d,
-      key: d.key,
-      x: xScale(i),
-      i
-    }));
+      const transformedData = data.map((d, i) => ({
+        ...d,
+        key: d.key,
+        x: xScale(i),
+        i
+      }));
 
-    return {
-      data: transformedData,
-      yScale,
-      xScale
-    };
-  }, [data]);
+      return {
+        data: transformedData,
+        yScale,
+        xScale
+      };
+    },
+    [data]
+  );
 
   const { datas, halfOffset } = useMemo(() => {
     // The 'layered' variant is actually just a series of funnel charts
@@ -98,33 +96,38 @@ export const FunnelSeries: React.FC<Partial<FunnelSeriesProps>> = ({
         datas: [
           { data, ...getScales(height, width) },
           { data, ...getScales(height - offset, width) },
-          { data, ...getScales(height - (offset * 2), width) }        ]
+          { data, ...getScales(height - offset * 2, width) }
+        ]
       };
     } else {
       return {
         halfOffset: 0,
-        datas: [
-          { data, ...getScales(height, width) }
-        ]
+        datas: [{ data, ...getScales(height, width) }]
       };
     }
   }, [data, arc, height, width, getScales]);
 
-  const handleSegmentClick = useCallback((e: MouseEvent) => {
-    if (onSegmentClick) {
-      const { xScale, data } = datas[0];
-      const { clientX, clientY, target } = e;
-      const position = getPositionForTarget({ target, clientX, clientY });
-      const value = getClosestContinousScalePoint(position.x, xScale, data, {
-        attr: 'i'
-      });
+  const handleSegmentClick = useCallback(
+    (e: MouseEvent) => {
+      if (onSegmentClick) {
+        const { xScale, data } = datas[0];
+        const { clientX, clientY, target } = e;
+        const position = getPositionForTarget({ target, clientX, clientY });
+        const value = getClosestContinousScalePoint({
+          pos: position.x,
+          scale: xScale,
+          data,
+          attr: 'i'
+        });
 
-      onSegmentClick({
-        value: { key: value.key, data: value.data },
-        nativeEvent: e
-      });
-    }
-  }, [datas, onSegmentClick]);
+        onSegmentClick({
+          value: { key: value.key, data: value.data },
+          nativeEvent: e
+        });
+      }
+    },
+    [datas, onSegmentClick]
+  );
 
   return (
     <>

--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -1,4 +1,13 @@
-import React, { Fragment, ReactElement, useState, useRef, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
+import React, {
+  Fragment,
+  ReactElement,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  forwardRef,
+  useImperativeHandle
+} from 'react';
 import { TooltipAreaEvent } from './TooltipAreaEvent';
 import { Placement } from 'rdk';
 import {
@@ -7,7 +16,11 @@ import {
   ChartInternalShallowDataShape,
   ChartInternalNestedDataShape
 } from '../data';
-import { getPositionForTarget, getClosestContinousScalePoint, getClosestBandScalePoint } from '../utils/position';
+import {
+  getPositionForTarget,
+  getClosestContinousScalePoint,
+  getClosestBandScalePoint
+} from '../utils/position';
 import { CloneElement } from 'rdk';
 import { ChartTooltip, ChartTooltipProps } from './ChartTooltip';
 import { arc } from 'd3-shape';
@@ -120,367 +133,416 @@ interface TooltipDataShape {
   x?: ChartDataTypes;
   y?: ChartDataTypes;
   data?: ChartDataTypes | Array<ChartDataTypes | ChartInternalShallowDataShape>;
-  i?: number
+  i?: number;
 }
 
 // eslint-disable-next-line react/display-name
-export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(({
-  children,
-  inverse,
-  tooltip,
-  disabled,
-  color,
-  isRadial,
-  isContinous,
-  width,
-  height,
-  xScale,
-  yScale,
-  onValueEnter,
-  data,
-  isHorizontal,
-  innerRadius,
-  outerRadius,
-  placement: placementProp,
-  onValueLeave,
-  startAngle,
-  endAngle
-}, childRef) => {
-  const [visible, setVisible] = useState<boolean>();
-  const [placement, setPlacement] = useState<Placement>();
-  const [value, setValue] = useState<any>();
-  const [offsetX, setOffsetX] = useState<any>();
-  const [offsetY, setOffsetY] = useState<any>();
-  const [prevX, setPrevX] = useState<number>();
-  const [prevY, setPrevY] = useState<number>();
-  const ref = useRef<SVGRectElement | SVGPathElement | any>();
-  const fullCircleref = useRef<SVGRectElement | SVGPathElement | any>(null);
-  const isFullCircle = Math.abs(endAngle - startAngle) >= 2 * Math.PI;
+export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
+  (
+    {
+      children,
+      inverse,
+      tooltip,
+      disabled,
+      color,
+      isRadial,
+      isContinous,
+      width,
+      height,
+      xScale,
+      yScale,
+      onValueEnter,
+      data,
+      isHorizontal,
+      innerRadius,
+      outerRadius,
+      placement: placementProp,
+      onValueLeave,
+      startAngle,
+      endAngle
+    },
+    childRef
+  ) => {
+    const [visible, setVisible] = useState<boolean>();
+    const [placement, setPlacement] = useState<Placement>();
+    const [value, setValue] = useState<any>();
+    const [offsetX, setOffsetX] = useState<any>();
+    const [offsetY, setOffsetY] = useState<any>();
+    const [prevX, setPrevX] = useState<number>();
+    const [prevY, setPrevY] = useState<number>();
+    const ref = useRef<SVGRectElement | SVGPathElement | any>();
+    const fullCircleref = useRef<SVGRectElement | SVGPathElement | any>(null);
+    const isFullCircle = Math.abs(endAngle - startAngle) >= 2 * Math.PI;
 
-  const range = Math.abs(endAngle - startAngle);
+    const range = Math.abs(endAngle - startAngle);
 
+    const rotationFactor = 0.5;
 
-  const rotationFactor = 0.5;
+    const getXCoord = useCallback(
+      (x: number, y: number) => {
+        // If the shape is radial, we need to convert the X coords to a radial format.
+        if (isRadial) {
+          const outerRadiusNew = outerRadius || Math.min(width, height) / 2;
+          let rad =
+            Math.atan2(y - outerRadiusNew, x - outerRadiusNew) +
+            rotationFactor * Math.PI;
 
-  const getXCoord = useCallback((x: number, y: number) => {
-    // If the shape is radial, we need to convert the X coords to a radial format.
-    if (isRadial) {
-      const outerRadiusNew = outerRadius || (Math.min(width, height) / 2);
-      let rad = Math.atan2(y - outerRadiusNew, x - outerRadiusNew) + (rotationFactor * Math.PI);
+          // Align it with the expected start angle
+          rad = (rad - startAngle) % (2 * Math.PI);
 
-      // Align it with the expected start angle
-      rad = (rad - startAngle) % (2 * Math.PI);
+          // TODO: Figure out what the 'correct' way to do this is...
+          if (rad < 0) {
+            rad += Math.PI * 2;
+          }
 
-      // TODO: Figure out what the 'correct' way to do this is...
-      if (rad < 0) {
-        rad += Math.PI * 2;
-      }
+          // convert to given range
+          const scale = scaleLinear()
+            .domain([0, range])
+            .range([startAngle, endAngle]);
+          rad = scale(rad);
 
-      // convert to given range
-      const scale = scaleLinear().domain([0, range]).range([startAngle, endAngle]);
-      rad = scale(rad);
+          return rad;
+        }
 
-      return rad;
-    }
+        return x;
+      },
+      [endAngle, height, isRadial, outerRadius, range, startAngle, width]
+    );
 
-    return x;
-  }, [endAngle, height, isRadial, outerRadius, range, startAngle, width]);
+    const transformData = useCallback(
+      (series: ChartInternalDataShape[]) => {
+        const result: TooltipDataShape[] = [];
 
-  const transformData = useCallback((series: ChartInternalDataShape[]) => {
-    const result: TooltipDataShape[] = [];
+        if (inverse) {
+          for (const point of series) {
+            const seriesPoint = point as ChartInternalNestedDataShape;
+            if (Array.isArray(seriesPoint.data)) {
+              for (const nestedPoint of seriesPoint.data) {
+                const right = nestedPoint.x;
+                let idx = result.findIndex((r) => {
+                  const left = r.x;
+                  if (left instanceof Date && right instanceof Date) {
+                    return left.getTime() === right.getTime();
+                  }
+                  return left === right;
+                });
 
-    if (inverse) {
-      for (const point of series) {
-        const seriesPoint = point as ChartInternalNestedDataShape;
-        if (Array.isArray(seriesPoint.data)) {
-          for (const nestedPoint of seriesPoint.data) {
-            const right = nestedPoint.x;
-            let idx = result.findIndex((r) => {
-              const left = r.x;
-              if (left instanceof Date && right instanceof Date) {
-                return left.getTime() === right.getTime();
+                if (idx === -1) {
+                  result.push({
+                    x: nestedPoint.x,
+                    data: []
+                  });
+
+                  idx = result.length - 1;
+                }
+
+                const data = result[idx].data;
+
+                if (Array.isArray(data)) {
+                  data.push(nestedPoint);
+                }
               }
-              return left === right;
-            });
-
-            if (idx === -1) {
-              result.push({
-                x: nestedPoint.x,
-                data: []
-              });
-
-              idx = result.length - 1;
-            }
-
-            const data = result[idx].data;
-
-            if (Array.isArray(data)) {
-              data.push(nestedPoint);
+            } else {
+              result.push(point);
             }
           }
         } else {
-          result.push(point);
+          for (const point of series) {
+            const nestedPoint = point as ChartInternalNestedDataShape;
+            if (Array.isArray(nestedPoint.data)) {
+              result.push({
+                ...nestedPoint,
+                x: nestedPoint.key,
+                data: nestedPoint.data.map((d) => ({
+                  ...d,
+                  key: !isHorizontal ? d.x : d.y,
+                  value: !isHorizontal ? d.y : d.x
+                }))
+              });
+            } else {
+              const shallowPoint = point as ChartInternalShallowDataShape;
+              result.push({
+                ...shallowPoint,
+                // Histograms special logic...
+                x: shallowPoint.key === undefined ? shallowPoint.x0 : point.key,
+                y:
+                  shallowPoint.value === undefined
+                    ? shallowPoint.y
+                    : shallowPoint.value
+              });
+            }
+          }
         }
-      }
-    } else {
-      for (const point of series) {
-        const nestedPoint = point as ChartInternalNestedDataShape;
-        if (Array.isArray(nestedPoint.data)) {
-          result.push({
-            ...nestedPoint,
-            x: nestedPoint.key,
-            data: nestedPoint.data.map((d) => ({
-              ...d,
-              key: !isHorizontal ? d.x : d.y,
-              value: !isHorizontal ? d.y : d.x
-            }))
-          });
+
+        return result;
+      },
+      [inverse, isHorizontal]
+    );
+
+    const onMouseMove = useCallback(
+      (event: React.MouseEvent) => {
+        const transformed = transformData(data);
+
+        // Get our default placement
+        let newPlacement = placementProp;
+        if (!placementProp) {
+          if (isHorizontal) {
+            newPlacement = 'right';
+          } else {
+            newPlacement = 'top';
+          }
+        }
+
+        // Get the path container element
+        // Note that we are using the dummy 'full' circle for alignment
+        let target = fullCircleref.current || ref.current;
+
+        const { y, x } = getPositionForTarget({
+          target: target,
+          // Manually pass the x/y from the event
+          clientX: event.clientX,
+          clientY: event.clientY
+        });
+
+        // Need to flip scales/coords if we are a horz layout
+        let keyScale;
+        let valueScale;
+        let coord;
+        let attr = 'x';
+        if (isHorizontal) {
+          keyScale = yScale;
+          valueScale = xScale;
+          coord = y;
         } else {
-          const shallowPoint = point as ChartInternalShallowDataShape;
-          result.push({
-            ...shallowPoint,
-            // Histograms special logic...
-            x: shallowPoint.key === undefined ? shallowPoint.x0 : point.key,
-            y:
-              shallowPoint.value === undefined
-                ? shallowPoint.y
-                : shallowPoint.value
+          coord = getXCoord(x, y);
+          keyScale = xScale;
+          valueScale = yScale;
+        }
+
+        // If an index value exists in the data, use that to grab closest point
+        if (typeof transformed[0].i === 'number') {
+          attr = 'i';
+        }
+
+        // Get the closest point to the mouse
+        // Consider invertable scales to be continous
+        // Round non-continous charts with a continous scale down
+        // Round band scales to the closest point for radial charts
+        const newValue = keyScale.invert
+          ? getClosestContinousScalePoint({
+            pos: coord,
+            scale: keyScale,
+            data: transformed,
+            attr,
+            roundDown: !isContinous
+          })
+          : getClosestBandScalePoint({
+            pos: coord,
+            scale: keyScale,
+            data: transformed,
+            attr,
+            roundClosest: isRadial
+          });
+
+        if (!isEqual(newValue, value) && newValue) {
+          const pointX = keyScale(newValue.x);
+          let pointY = valueScale(newValue.y);
+          let marginX = 0;
+          let marginY = 0;
+
+          if (isNaN(pointY)) {
+            pointY = height / 2;
+            marginX = 10;
+            if (!placement) {
+              newPlacement = 'right';
+            }
+          } else {
+            marginY = -10;
+          }
+
+          // If the points didn't change, don't trigger an update
+          if (pointX === prevX && pointY === prevY) {
+            return;
+          }
+
+          setPrevX(pointX);
+          setPrevY(pointY);
+
+          const target = event.target as SVGRectElement;
+          const { top, left } = target.getBoundingClientRect();
+
+          let offsetX = 0;
+          let offsetY = 0;
+
+          if (isRadial) {
+            // If its radial, we need to convert the coords to radial format
+            const outerRadius = Math.min(width, height) / 2;
+            offsetX =
+              pointY * Math.cos(pointX - rotationFactor * Math.PI) +
+              outerRadius;
+            offsetY =
+              pointY * Math.sin(pointX - rotationFactor * Math.PI) +
+              outerRadius;
+          } else {
+            offsetX = pointX;
+            offsetY = pointY;
+          }
+
+          offsetX += left + marginX;
+          offsetY += top + marginY;
+
+          setPlacement(newPlacement);
+          setVisible(true);
+          setValue(newValue);
+          setOffsetX(offsetX);
+          setOffsetY(offsetY);
+
+          onValueEnter({
+            visible: true,
+            value: newValue,
+            pointY,
+            pointX,
+            offsetX,
+            offsetY,
+            nativeEvent: event
           });
         }
+      },
+      [
+        data,
+        getXCoord,
+        height,
+        isContinous,
+        isHorizontal,
+        isRadial,
+        onValueEnter,
+        placement,
+        placementProp,
+        prevX,
+        prevY,
+        transformData,
+        value,
+        width,
+        xScale,
+        yScale
+      ]
+    );
+
+    const onMouseLeave = useCallback(() => {
+      setPrevX(undefined);
+      setPrevY(undefined);
+
+      setValue(undefined);
+      setVisible(false);
+
+      onValueLeave();
+    }, [onValueLeave]);
+
+    useImperativeHandle(childRef, () => ({
+      triggerMouseMove(e: React.MouseEvent) {
+        onMouseMove(e);
       }
-    }
+    }));
 
-    return result;
-  }, [inverse, isHorizontal]);
+    const tooltipReference = useMemo(
+      () => ({
+        width: 4,
+        height: 4,
+        top: offsetY,
+        left: offsetX
+      }),
+      [offsetX, offsetY]
+    );
 
-  const onMouseMove = useCallback((event: React.MouseEvent) => {
-    const transformed = transformData(data);
+    const renderRadial = useCallback(() => {
+      const innerRadiusNew = innerRadius || 0;
+      const outerRadiusNew = outerRadius || Math.min(width, height) / 2;
 
-    // Get our default placement
-    let newPlacement = placementProp;
-    if (!placementProp) {
-      if (isHorizontal) {
-        newPlacement = 'right';
-      } else {
-        newPlacement = 'top';
-      }
-    }
-
-    // Get the path container element
-    // Note that we are using the dummy 'full' circle for alignment
-    let target = fullCircleref.current || ref.current;
-
-    const { y, x } = getPositionForTarget({
-      target: target,
-      // Manually pass the x/y from the event
-      clientX: event.clientX,
-      clientY: event.clientY
-    });
-
-    // Need to flip scales/coords if we are a horz layout
-    let keyScale;
-    let valueScale;
-    let coord;
-    let attr = 'x';
-    if (isHorizontal) {
-      keyScale = yScale;
-      valueScale = xScale;
-      coord = y;
-    } else {
-      coord = getXCoord(x, y);
-      keyScale = xScale;
-      valueScale = yScale;
-    }
-
-    // If an index value exists in the data, use that to grab closest point
-    if (typeof transformed[0].i === 'number') {
-      attr = 'i';
-    }
-
-    // Get the closest point to the mouse
-    // Consider invertable scales to be continous
-    // Round non-continous charts with a continous scale down
-    // Round band scales to the closest point for radial charts
-    const newValue = keyScale.invert
-      ? getClosestContinousScalePoint(coord, keyScale, transformed, {
-        attr,
-        roundDown: !isContinous
-      })
-      : getClosestBandScalePoint(coord, keyScale, transformed, {
-        attr,
-        roundClosest: isRadial
+      const d = arc()({
+        innerRadius: innerRadiusNew,
+        outerRadius: outerRadiusNew,
+        startAngle: isFullCircle ? 0 : startAngle,
+        endAngle: isFullCircle ? 2 * Math.PI : endAngle
       });
 
-    if (!isEqual(newValue, value) && newValue) {
-      const pointX = keyScale(newValue.x);
-      let pointY = valueScale(newValue.y);
-      let marginX = 0;
-      let marginY = 0;
-
-      if (isNaN(pointY)) {
-        pointY = height / 2;
-        marginX = 10;
-        if (!placement) {
-          newPlacement = 'right';
-        }
-      } else {
-        marginY = -10;
-      }
-
-      // If the points didn't change, don't trigger an update
-      if (pointX === prevX && pointY === prevY) {
-        return;
-      }
-
-      setPrevX(pointX);
-      setPrevY(pointY);
-
-      const target = event.target as SVGRectElement;
-      const { top, left } = target.getBoundingClientRect();
-
-      let offsetX = 0;
-      let offsetY = 0;
-
-      if (isRadial) {
-        // If its radial, we need to convert the coords to radial format
-        const outerRadius = Math.min(width, height) / 2;
-        offsetX = pointY * Math.cos(pointX - (rotationFactor * Math.PI)) + outerRadius;
-        offsetY = pointY * Math.sin(pointX - (rotationFactor * Math.PI)) + outerRadius;
-      } else {
-        offsetX = pointX;
-        offsetY = pointY;
-      }
-
-      offsetX += left + marginX;
-      offsetY += top + marginY;
-
-
-      setPlacement(newPlacement);
-      setVisible(true);
-      setValue(newValue);
-      setOffsetX(offsetX);
-      setOffsetY(offsetY);
-
-      onValueEnter({
-        visible: true,
-        value: newValue,
-        pointY,
-        pointX,
-        offsetX,
-        offsetY,
-        nativeEvent: event
+      // This is a dummuy full circle in the background as we need the
+      // full circle to get the coordinates right from getBoundingClientRect().
+      // If we don't use a full circle, then the bounding rectangle could be of any dimension and
+      // the logic in getPositionForTarget() wouldn't work
+      const fullCircle = arc()({
+        innerRadius: innerRadiusNew,
+        outerRadius: outerRadiusNew,
+        startAngle: 0,
+        endAngle: 2 * Math.PI
       });
-    }
-  }, [data, getXCoord, height, isContinous, isHorizontal, isRadial, onValueEnter, placement, placementProp, prevX, prevY, transformData, value, width, xScale, yScale]);
 
-  const onMouseLeave = useCallback(() => {
-    setPrevX(undefined);
-    setPrevY(undefined);
+      return (
+        <>
+          <path d={fullCircle!} opacity="0" cursor="auto" ref={fullCircleref} />
+          <path
+            d={d!}
+            opacity="0"
+            cursor="auto"
+            ref={ref}
+            onMouseMove={onMouseMove}
+          />
+        </>
+      );
+    }, [
+      endAngle,
+      height,
+      innerRadius,
+      isFullCircle,
+      onMouseMove,
+      outerRadius,
+      startAngle,
+      width
+    ]);
 
-    setValue(undefined);
-    setVisible(false);
-
-    onValueLeave();
-  }, [onValueLeave]);
-
-  useImperativeHandle(childRef, () => ({
-    triggerMouseMove(e: React.MouseEvent) {
-      onMouseMove(e);
-    }
-  }));
-
-  const tooltipReference = useMemo(() => ({
-    width: 4,
-    height: 4,
-    top: offsetY,
-    left: offsetX
-  }), [offsetX, offsetY]);
-
-  const renderRadial = useCallback(() => {
-    const innerRadiusNew = innerRadius || 0;
-    const outerRadiusNew = outerRadius || Math.min(width, height) / 2;
-
-    const d = arc()({
-      innerRadius: innerRadiusNew,
-      outerRadius: outerRadiusNew,
-      startAngle: isFullCircle ? 0 : startAngle,
-      endAngle: isFullCircle ? 2 * Math.PI : endAngle
-    });
-
-
-    // This is a dummuy full circle in the background as we need the
-    // full circle to get the coordinates right from getBoundingClientRect().
-    // If we don't use a full circle, then the bounding rectangle could be of any dimension and
-    // the logic in getPositionForTarget() wouldn't work
-    const fullCircle = arc()({
-      innerRadius: innerRadiusNew,
-      outerRadius: outerRadiusNew,
-      startAngle: 0,
-      endAngle: 2 * Math.PI
-    });
-
-
-    return (
-      <>
-        <path
-          d={fullCircle!}
-          opacity="0"
-          cursor="auto"
-          ref={fullCircleref}
-        />
-        <path
-          d={d!}
-          opacity="0"
-          cursor="auto"
+    const renderLinear = useCallback(() => {
+      return (
+        <rect
+          height={height}
           ref={ref}
+          width={width}
+          opacity={0}
+          cursor="auto"
           onMouseMove={onMouseMove}
         />
-      </>
-    );
-  }, [endAngle, height, innerRadius, isFullCircle, onMouseMove, outerRadius, startAngle, width]);
+      );
+    }, [height, onMouseMove, width]);
 
-  const renderLinear = useCallback(() => {
     return (
-      <rect
-        height={height}
-        ref={ref}
-        width={width}
-        opacity={0}
-        cursor="auto"
-        onMouseMove={onMouseMove}
-      />
+      <Fragment>
+        {disabled && children}
+        {!disabled && (
+          <g onMouseLeave={onMouseLeave} ref={childRef}>
+            {isRadial && renderRadial()}
+            {!isRadial && renderLinear()}
+            <CloneElement<ChartTooltipProps>
+              element={tooltip}
+              visible={visible}
+              placement={placement}
+              modifiers={{
+                offset: {
+                  offset: '0, 15px'
+                }
+              }}
+              reference={tooltipReference}
+              color={color}
+              value={value}
+            />
+            {children}
+          </g>
+        )}
+      </Fragment>
     );
-  }, [height, onMouseMove, width]);
-
-  return (
-    <Fragment>
-      {disabled && children}
-      {!disabled && (
-        <g onMouseLeave={onMouseLeave} ref={childRef}>
-          {isRadial && renderRadial()}
-          {!isRadial && renderLinear()}
-          <CloneElement<ChartTooltipProps>
-            element={tooltip}
-            visible={visible}
-            placement={placement}
-            modifiers={{
-              offset: {
-                offset: '0, 15px'
-              }
-            }}
-            reference={tooltipReference}
-            color={color}
-            value={value}
-          />
-          {children}
-        </g>
-      )}
-    </Fragment>
-  );
-});
+  }
+);
 
 TooltipArea.defaultProps = {
   isRadial: false,
+  isContinous: true,
   tooltip: <ChartTooltip />,
   inverse: true,
   onValueEnter: () => undefined,

--- a/src/common/utils/position.test.ts
+++ b/src/common/utils/position.test.ts
@@ -1,0 +1,62 @@
+import { scaleBand, scaleLinear, scaleTime } from 'd3-scale';
+import {
+  getClosestBandScalePoint,
+  getClosestContinousScalePoint
+} from './position';
+import { describe, test } from 'vitest';
+
+describe('getClosestContinousScalePoint', () => {
+  test('returns the closest point for an invertible/continous scale', ({
+    expect
+  }) => {
+    const data = [{ x: 4 }, { x: 6 }];
+
+    let scale = scaleLinear().rangeRound([0, 300]);
+    scale = scale.domain([4, 6]);
+
+    const result = getClosestContinousScalePoint(150, scale, data);
+
+    expect(result).toEqual({ x: 6 });
+  });
+
+  test('returns the closest point rounded down for an invertible/continous scale', ({
+    expect
+  }) => {
+    const data = [{ x: 4 }, { x: 6 }];
+
+    let scale = scaleLinear().rangeRound([0, 300]);
+    scale = scale.domain([4, 6]);
+
+    const result = getClosestContinousScalePoint(150, scale, data, {
+      roundDown: true
+    });
+
+    expect(result).toEqual({ x: 4 });
+  });
+});
+
+describe('getClosestBandScalePoint', () => {
+  test('returns the closest point for a band scale rounded down', ({
+    expect
+  }) => {
+    const scale = scaleBand().rangeRound([0, 100]).domain(['a', 'b', 'c']);
+
+    const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
+
+    const result = getClosestBandScalePoint(32, scale, data);
+
+    expect(result).toEqual({ x: 'a' });
+  });
+
+  test('returns the closest point for a band scale', ({ expect }) => {
+    const scale = scaleBand().rangeRound([0, 100]).domain(['a', 'b', 'c']);
+
+    const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
+
+    const result = getClosestBandScalePoint(32, scale, data, {
+      roundClosest: true
+    });
+
+    expect(result).toEqual({ x: 'b' });
+  });
+});

--- a/src/common/utils/position.test.ts
+++ b/src/common/utils/position.test.ts
@@ -12,7 +12,7 @@ describe('getClosestContinousScalePoint', () => {
   test('returns the closest point for an invertible/continous scale', ({
     expect
   }) => {
-    const result = getClosestContinousScalePoint(150, scale, data);
+    const result = getClosestContinousScalePoint({ pos: 150, scale, data });
 
     expect(result).toEqual({ x: 6 });
   });
@@ -20,7 +20,10 @@ describe('getClosestContinousScalePoint', () => {
   test('returns the closest point rounded down for an invertible/continous scale', ({
     expect
   }) => {
-    const result = getClosestContinousScalePoint(150, scale, data, {
+    const result = getClosestContinousScalePoint({
+      pos: 150,
+      scale,
+      data,
       roundDown: true
     });
 
@@ -35,13 +38,16 @@ describe('getClosestBandScalePoint', () => {
   test('returns the closest point for a band scale rounded down', ({
     expect
   }) => {
-    const result = getClosestBandScalePoint(32, scale, data);
+    const result = getClosestBandScalePoint({ pos: 32, scale, data });
 
     expect(result).toEqual({ x: 'a' });
   });
 
   test('returns the closest point for a band scale', ({ expect }) => {
-    const result = getClosestBandScalePoint(32, scale, data, {
+    const result = getClosestBandScalePoint({
+      pos: 32,
+      scale,
+      data,
       roundClosest: true
     });
 

--- a/src/common/utils/position.test.ts
+++ b/src/common/utils/position.test.ts
@@ -6,14 +6,12 @@ import {
 import { describe, test } from 'vitest';
 
 describe('getClosestContinousScalePoint', () => {
+  const data = [{ x: 4 }, { x: 6 }];
+  const scale = scaleLinear().rangeRound([0, 300]).domain([4, 6]);
+
   test('returns the closest point for an invertible/continous scale', ({
     expect
   }) => {
-    const data = [{ x: 4 }, { x: 6 }];
-
-    let scale = scaleLinear().rangeRound([0, 300]);
-    scale = scale.domain([4, 6]);
-
     const result = getClosestContinousScalePoint(150, scale, data);
 
     expect(result).toEqual({ x: 6 });
@@ -22,11 +20,6 @@ describe('getClosestContinousScalePoint', () => {
   test('returns the closest point rounded down for an invertible/continous scale', ({
     expect
   }) => {
-    const data = [{ x: 4 }, { x: 6 }];
-
-    let scale = scaleLinear().rangeRound([0, 300]);
-    scale = scale.domain([4, 6]);
-
     const result = getClosestContinousScalePoint(150, scale, data, {
       roundDown: true
     });
@@ -36,23 +29,18 @@ describe('getClosestContinousScalePoint', () => {
 });
 
 describe('getClosestBandScalePoint', () => {
+  const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
+  const scale = scaleBand().rangeRound([0, 100]).domain(['a', 'b', 'c']);
+
   test('returns the closest point for a band scale rounded down', ({
     expect
   }) => {
-    const scale = scaleBand().rangeRound([0, 100]).domain(['a', 'b', 'c']);
-
-    const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
-
     const result = getClosestBandScalePoint(32, scale, data);
 
     expect(result).toEqual({ x: 'a' });
   });
 
   test('returns the closest point for a band scale', ({ expect }) => {
-    const scale = scaleBand().rangeRound([0, 100]).domain(['a', 'b', 'c']);
-
-    const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
-
     const result = getClosestBandScalePoint(32, scale, data, {
       roundClosest: true
     });

--- a/src/common/utils/position.ts
+++ b/src/common/utils/position.ts
@@ -39,29 +39,31 @@ const scaleBandInvert = (scale, round = false) => {
   };
 };
 
-type GetClosestContinousPointOptions = {
-  attr?: string;
-  roundDown?: boolean;
-};
-
 /**
- * Get the closest point on a continuous scale.
+ * Get the data point closest to a given position on a continuous scale.
  *
- * @param {number} pos - The position to find the closest point to.
- * @param {Object} scale - The scale object.
- * @param {Array} data - The data array.
- * @param {Object} [options={}] - Optional parameters.
- * @param {string} [options.attr='x'] - The attribute to use for comparison.
- * @param {boolean} [options.roundDown=false] - Whether to round down to the nearest point.
+ * @param {Object} params - The parameters for the function.
+ * @param {number} params.pos - The position to find the closest point to.
+ * @param {Object} params.scale - The scale object.
+ * @param {Array} params.data - The data array.
+ * @param {string} [params.attr='x'] - The attribute to use for comparison.
+ * @param {boolean} [params.roundDown=false] - Whether to round down to the nearest point.
  *
  * @returns {Object} The closest point to the specified position.
  */
-export const getClosestContinousScalePoint = (
-  pos: number,
+export const getClosestContinousScalePoint = ({
+  pos,
   scale,
   data,
-  { attr = 'x', roundDown = false }: GetClosestContinousPointOptions = {}
-) => {
+  attr = 'x',
+  roundDown = false
+}: {
+  pos: number;
+  scale: any;
+  data: any[];
+  attr?: string;
+  roundDown?: boolean;
+}) => {
   const domain = scale.invert(pos);
 
   // Select the index
@@ -92,27 +94,28 @@ export const getClosestContinousScalePoint = (
   return beforeVal < afterVal ? before : after;
 };
 
-type GetClosestBandScalePointOptions = {
-  roundClosest?: boolean;
-};
-
 /**
- * Get the closest point on a band scale.
+ * Get the data point closest to a given position on a band scale. This rounds down by default.
  *
- * @param {number} pos - The position to find the closest point to.
- * @param {Object} scale - The scale object.
- * @param {Array} data - The data array.
- * @param {Object} [options={}] - Optional parameters.
- * @param {boolean} [options.roundClosest=false] - Whether to round to the closest point instead of down.
+ * @param {Object} params - The parameters for the function.
+ * @param {number} params.pos - The position to find the closest point to.
+ * @param {Object} params.scale - The scale object.
+ * @param {Array} params.data - The data array.
+ * @param {boolean} [params.roundClosest=false] - Whether to round to the closest point instead of down.
  *
  * @returns {Object} The closest point to the specified position.
  */
-export const getClosestBandScalePoint = (
-  pos: number,
+export const getClosestBandScalePoint = ({
+  pos,
   scale,
   data,
-  { roundClosest = false }: GetClosestBandScalePointOptions = {}
-) => {
+  roundClosest = false
+}: {
+  pos: number;
+  scale: any;
+  data: any[];
+  roundClosest?: boolean;
+}) => {
   const domain = scale.domain();
   let prop;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Tooltips aren't accurate on bar charts using continuous x scales. It shows the tooltip for the next data point halfway through the one you're hovering

## What is the new behavior?
The correct tooltip shows for the bar you are hovering over

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
BEFORE

https://github.com/reaviz/reaviz/assets/40581813/4444685a-c015-42eb-b63e-2ad39c9bbfbe


AFTER

https://github.com/reaviz/reaviz/assets/40581813/9a9f2cd2-b367-4100-b643-a425c4fd1092

