### PR TITLE
Improve multi-series area chart glow

### DIFF
--- a/src/AreaChart/AreaSeries/Area.tsx
+++ b/src/AreaChart/AreaSeries/Area.tsx
@@ -202,11 +202,11 @@ export const Area: FC<Partial<AreaProps>> = ({
         }}
         style={{
           ...extras.style,
-          ...generateGlowStyles({ glow })
+          ...generateGlowStyles({ glow, colorSchemeColor: stroke })
         }}
       />
     );
-  }, [data, enter, exit, fill, glow, id, mask, rest, transition]);
+  }, [data, enter, exit, fill, glow, id, mask, rest, stroke, transition]);
 
   return (
     <Fragment>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Improvement
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Multi-series area charts can only glow one color


## What is the new behavior?
If you don't specify an area glow color, it will use the stroke color which is based off the color scheme

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If a glow color's not specified, this will use the color of the area stroke

This allows multiseries data to glow different colors based off the color scheme
