### PR TITLE
Fix heatmap cell styling

### DIFF
--- a/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
@@ -93,10 +93,7 @@ export const HeatmapSeries: FC<Partial<HeatmapSeriesProps>> = ({
   }) => {
     const x = xScale(row.key);
     const y = yScale(cell.x);
-    const { fill, stroke, filter } = getColorSchemeStyles(
-      cell,
-      valueScales
-    );
+    const style = getColorSchemeStyles(cell, valueScales);
 
     return (
       <CloneElement<HeatmapCellProps>
@@ -107,12 +104,12 @@ export const HeatmapSeries: FC<Partial<HeatmapSeriesProps>> = ({
         cellCount={cellCount}
         x={x}
         y={y}
-        fill={fill}
-        stroke={stroke}
+        fill={style?.fill}
+        stroke={style?.stroke}
         width={width}
         height={height}
         data={cell}
-        style={{ filter }}
+        style={style}
       />
     );
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Heatmap cell styling is limited even though the type on `colorScheme` implies you can pass any style you want

## What is the new behavior?
You can pass any style in `colorScheme` and it reflects in heatmap cells

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
e.g. I want to pass a `colorScheme` with styling like `strokeWidth`

```
colorScheme={[
  { fill: '#9152EE40', stroke: '#9152EE', strokeWidth: '2px' }
  { fill: '#9152EE' },
  { fill: '#F8A340' },
  { fill: '#FFD440', filter: 'drop-shadow(0px 0px 5px #FFD440)' }
]}
```
