### PR TITLE
Fix HeatmapCalendar not showing all data

### DIFF
--- a/src/Heatmap/calendarUtils.ts
+++ b/src/Heatmap/calendarUtils.ts
@@ -1,5 +1,6 @@
-import { range, min } from 'd3-array';
 import { ChartShallowDataShape } from '@/common/data';
+import { max, min, range } from 'd3-array';
+import { subDays } from 'date-fns';
 
 export type CalendarView = 'year' | 'month';
 
@@ -41,9 +42,18 @@ export const buildDataScales = (
   // From the end date, lets find the start year/month of that
   // From that start year/month, lets find the end year/month for our bounds
   const startDate = min(rawData, (d) => d.key) || new Date();
-  const start = getFirstOfMonth(startDate);
   const endDomain = view === 'year' ? 53 : 5;
-  const end = addWeeksToDate(start, endDomain);
+
+  let end, start;
+  if (view === 'year') {
+    // For year view, end at the most recent date and start 364 days before that
+    end = getStartOfDay(max(rawData, (d) => d.key) || new Date());
+    start = getStartOfDay(subDays(end, 365));
+  } else {
+    // For month view, start at the first of the month and end 4 weeks from that
+    start = getFirstOfMonth(startDate);
+    end = addWeeksToDate(start, endDomain);
+  }
 
   // Base on the view type, swap out some ranges
   const xDomainRange = view === 'year' ? 53 : 5;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Including 365 days of data to `HeatmapCalendar` doesn't display all the data

Issue Number: #237 


## What is the new behavior?
365 days of data (starting 364 days from most recent) is displayed in `HeatmapCalendar`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This was happening because the `year` view on `HeatmapCalendar` is restricted to 52 weeks while also transforming the start date to the first of the month of the earliest piece of data. This means some data towards the end of the date range could get chopped off

The calendar now ends at the most recent piece of data and starts 364 days before that

e.g. showing July 19 2023 - July 17 2024 (UTC)

**BEFORE**


https://github.com/user-attachments/assets/f0fc02e4-7d3a-46d9-a929-c26a0a6f43d5



**AFTER**


https://github.com/user-attachments/assets/44a8046b-b3ae-46dc-9e8a-4eea19bfb5fd



