### PR TITLE
Add keyboard navigation support to chart components

### DIFF
--- a/src/BarChart/BarSeries/Bar.tsx
+++ b/src/BarChart/BarSeries/Bar.tsx
@@ -475,6 +475,47 @@ export const Bar: FC<Partial<BarProps>> = (props) => {
     [data, onMouseLeave, tooltip]
   );
 
+  const onFocusInternal = useCallback(
+    (event) => {
+      if (tooltip) {
+        setInternalActive(true);
+      }
+
+      onMouseEnter?.({
+        value: data,
+        nativeEvent: event
+      });
+    },
+    [data, onMouseEnter, tooltip]
+  );
+
+  const onBlurInternal = useCallback(
+    (event) => {
+      if (tooltip) {
+        setInternalActive(false);
+      }
+
+      onMouseLeave?.({
+        value: data,
+        nativeEvent: event
+      });
+    },
+    [data, onMouseLeave, tooltip]
+  );
+
+  const onKeyDownInternal = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick?.({
+          value: data,
+          nativeEvent: event as any
+        });
+      }
+    },
+    [data, onClick]
+  );
+
   const onMouseClick = useCallback(
     (event) => {
       onClick?.({
@@ -611,6 +652,9 @@ export const Bar: FC<Partial<BarProps>> = (props) => {
             transition={transition}
             onMouseEnter={onMouseEnterInternal}
             onMouseLeave={onMouseLeaveInternal}
+            onFocus={onFocusInternal}
+            onBlur={onBlurInternal}
+            onKeyDown={onKeyDownInternal}
             onClick={onMouseClick}
             onMouseMove={onMouseMove}
             tabIndex={0}
@@ -633,6 +677,9 @@ export const Bar: FC<Partial<BarProps>> = (props) => {
       onMouseClick,
       onMouseEnterInternal,
       onMouseLeaveInternal,
+      onFocusInternal,
+      onBlurInternal,
+      onKeyDownInternal,
       onMouseMove,
       rx,
       ry,

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -1,11 +1,13 @@
 import React, {
   FC,
   Fragment,
+  KeyboardEvent,
   MouseEvent,
   ReactElement,
   useMemo,
   useState,
   useRef,
+  useCallback,
   ReactNode
 } from 'react';
 import { flip, offset } from '@floating-ui/dom';
@@ -167,6 +169,35 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
     });
   };
 
+  const onFocusInternal = useCallback(() => {
+    setActive(true);
+    onMouseEnter({
+      value: data,
+      nativeEvent: null
+    });
+  }, [data, onMouseEnter]);
+
+  const onBlurInternal = useCallback(() => {
+    setActive(false);
+    onMouseLeave({
+      value: data,
+      nativeEvent: null
+    });
+  }, [data, onMouseLeave]);
+
+  const onKeyDownInternal = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick({
+          value: data,
+          nativeEvent: event as any
+        });
+      }
+    },
+    [data, onClick]
+  );
+
   const tooltipData = useMemo(
     () => ({
       y: data.value,
@@ -230,6 +261,9 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
             transition={transition}
             onPointerOver={pointerOver}
             onPointerOut={pointerOut}
+            onFocus={onFocusInternal}
+            onBlur={onBlurInternal}
+            onKeyDown={onKeyDownInternal}
             onClick={onMouseClick}
             tabIndex={0}
             aria-label={ariaLabelData}
@@ -260,6 +294,9 @@ export const HeatmapCell: FC<Partial<HeatmapCellProps>> = ({
             transition={transition}
             onPointerOver={pointerOver}
             onPointerOut={pointerOut}
+            onFocus={onFocusInternal}
+            onBlur={onBlurInternal}
+            onKeyDown={onKeyDownInternal}
             onClick={onMouseClick}
             tabIndex={0}
             aria-label={ariaLabelData}

--- a/src/PieChart/PieArcSeries/PieArc.tsx
+++ b/src/PieChart/PieArcSeries/PieArc.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, FC, useRef, useMemo } from 'react';
+import React, { ReactElement, useState, FC, useRef, useMemo, useCallback } from 'react';
 import chroma from 'chroma-js';
 import { motion, MotionStyle } from 'motion/react';
 import { CloneElement } from 'reablocks';
@@ -143,12 +143,42 @@ export const PieArc: FC<PieArcProps> = ({
   );
   const ariaLabelData = useMemo(() => getAriaLabel(tooltipData), [tooltipData]);
 
+  const onFocusInternal = useCallback(() => {
+    if (!disabled) {
+      setActive(true);
+    }
+  }, [disabled]);
+
+  const onBlurInternal = useCallback(() => {
+    if (!disabled) {
+      setActive(false);
+    }
+  }, [disabled]);
+
+  const onKeyDownInternal = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        if (!disabled) {
+          onClick?.({
+            value: data.data,
+            nativeEvent: event as any
+          });
+        }
+      }
+    },
+    [data, disabled, onClick]
+  );
+
   return (
     <g
       ref={arcRef}
       tabIndex={0}
       aria-label={ariaLabelData}
       role="graphics-document"
+      onFocus={onFocusInternal}
+      onBlur={onBlurInternal}
+      onKeyDown={onKeyDownInternal}
     >
       <motion.path
         role="graphics-symbol"

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
@@ -221,6 +221,20 @@ export const ScatterPoint: FC<Partial<ScatterPointProps>> = (props) => {
           setTooltipVisible(false);
           onMouseLeave(data!);
         }}
+        onFocus={() => {
+          setTooltipVisible(true);
+          onMouseEnter(data!);
+        }}
+        onBlur={() => {
+          setTooltipVisible(false);
+          onMouseLeave(data!);
+        }}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick(data!);
+          }
+        }}
         onClick={() => onClick(data!)}
         tabIndex={0}
         aria-label={ariaLabelData}

--- a/src/common/containers/ChartContainer.module.css
+++ b/src/common/containers/ChartContainer.module.css
@@ -35,5 +35,20 @@
     &:focus-visible {
       outline: auto;
     }
+
+    rect:focus-visible,
+    path:focus-visible,
+    circle:focus-visible,
+    g:focus-visible {
+      outline: 2px solid #67c2e4;
+      outline-offset: 1px;
+    }
+
+    rect:focus:not(:focus-visible),
+    path:focus:not(:focus-visible),
+    circle:focus:not(:focus-visible),
+    g:focus:not(:focus-visible) {
+      outline: none;
+    }
   }
 }

--- a/src/common/containers/ChartContainer.tsx
+++ b/src/common/containers/ChartContainer.tsx
@@ -57,6 +57,16 @@ export interface ChartProps {
    * Center chart on Y Axis only. Used mainly internally.
    */
   centerY?: boolean;
+
+  /**
+   * Accessible label for the chart SVG element.
+   */
+  'aria-label'?: string;
+
+  /**
+   * ID of an element that labels the chart SVG element.
+   */
+  'aria-labelledby'?: string;
 }
 
 export interface ChartContainerProps extends ChartProps {
@@ -90,6 +100,8 @@ export const ChartContainer: FC<ChartContainerProps> = ({
   xAxisVisible,
   yAxisVisible,
   id,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
   ...rest
 }) => {
   const curId = useId(id);
@@ -190,6 +202,9 @@ export const ChartContainer: FC<ChartContainerProps> = ({
             className={classNames(css.svg, className)}
             style={style}
             tabIndex={0}
+            role="img"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
           >
             <g transform={`translate(${translateX}, ${translateY})`}>
               {children(childProps)}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Chart components (Bar, Heatmap, PieArc, ScatterPoint) are only interactive via mouse events. Keyboard users cannot navigate or interact with chart elements.

## What is the new behavior?
Added comprehensive keyboard navigation support to chart components:

- **Focus/Blur handlers**: Components now respond to focus and blur events to show/hide tooltips and update visual state
- **Keyboard activation**: Enter and Space keys trigger click handlers on chart elements
- **Visual focus indicators**: Added CSS styling for focus-visible states with a blue outline (2px solid #67c2e4)
- **Accessibility attributes**: Added `aria-label` and `aria-labelledby` support to ChartContainer with `role="img"`
- **Consistent implementation**: Applied the same keyboard interaction pattern across Bar, HeatmapCell, PieArc, and ScatterPoint components

All interactive chart elements now have `tabIndex={0}` to be keyboard accessible and properly handle focus/blur/keydown events.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
- CSS focus styling follows accessibility best practices with focus-visible for keyboard users and hidden focus for mouse users
- All keyboard handlers prevent default behavior and delegate to existing click handlers
- Implementation maintains consistency with existing mouse event patterns

https://claude.ai/code/session_015JiNHfJsASg5rK1RWkdkC8