### PR TITLE
feat: Improve TooltipArea component with container constraint option for tooltip

### DIFF
--- a/src/AreaChart/AreaChartMultiSeries.story.tsx
+++ b/src/AreaChart/AreaChartMultiSeries.story.tsx
@@ -16,6 +16,7 @@ import {
   StackedAreaSeries,
   StackedNormalizedAreaSeries
 } from './AreaSeries';
+import { TooltipArea } from '@/common/Tooltip';
 
 export default {
   tags: ['snapshot'],
@@ -40,6 +41,25 @@ export const Simple = () => (
     series={<AreaSeries type="grouped" colorScheme="cybertron" />}
   />
 );
+
+// Hover the first/last data points: the tooltip slides to stay
+// inside the chart container instead of overflowing its edges
+export const ConstrainedTooltip = () => (
+  <AreaChart
+    id="constrained-tooltip"
+    width={550}
+    height={350}
+    data={multiDateData}
+    series={
+      <AreaSeries
+        type="grouped"
+        colorScheme="cybertron"
+        tooltip={<TooltipArea constrainToContainer />}
+      />
+    }
+  />
+);
+ConstrainedTooltip.tags = ['no-snapshot'];
 
 export const LargeDataset = () => (
   <AreaChart

--- a/src/AreaChart/AreaChartMultiSeries.story.tsx
+++ b/src/AreaChart/AreaChartMultiSeries.story.tsx
@@ -43,7 +43,7 @@ export const Simple = () => (
 );
 
 // Hover the first/last data points: the tooltip slides to stay
-// inside the chart container instead of overflowing its edges
+// inside the chart container instead of overflowing its edges.
 export const ConstrainedTooltip = () => (
   <AreaChart
     id="constrained-tooltip"

--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -148,7 +148,7 @@ export interface TooltipAreaProps {
    * When enabled, modifiers set on the tooltip element are honored and the
    * containment middleware is appended to them.
    *
-   * @default false
+   * @default true
    */
   constrainToContainer?: boolean;
 }
@@ -188,7 +188,7 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
       onValueLeave = () => undefined,
       startAngle = 0,
       endAngle = 2 * Math.PI,
-      constrainToContainer = false
+      constrainToContainer = true
     },
     childRef
   ) => {
@@ -615,14 +615,20 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
       );
     }, [height, onMouseMove, width]);
 
-    // The boundary must be an HTML element — SVG elements yield a degenerate
-    // clipping rect — so use the element wrapping the chart's root svg. Until
-    // the ref is set it stays undefined (`?? undefined` coerces null, which
-    // floating-ui does not treat as absent) and floating-ui falls back to its
-    // default viewport boundary.
-    const boundary = ref.current
-      ? (getParentSVG({ target: ref.current })?.parentElement ?? undefined)
-      : undefined;
+    // Boundary for constraining the tooltip: the HTML element wrapping the
+    // chart's root svg (SVG elements don't clip correctly). Resolved once on
+    // mount; while undefined, floating-ui falls back to the viewport.
+    const [boundary, setBoundary] = useState<HTMLElement | undefined>(
+      undefined
+    );
+    useEffect(() => {
+      if (constrainToContainer && ref.current) {
+        setBoundary(
+          getParentSVG({ target: ref.current })?.parentElement ?? undefined
+        );
+      }
+    }, [constrainToContainer, disabled]);
+
     const modifiers = useMemo(
       () =>
         constrainToContainer

--- a/src/common/Tooltip/TooltipArea.tsx
+++ b/src/common/Tooltip/TooltipArea.tsx
@@ -9,7 +9,7 @@ import React, {
   useImperativeHandle,
   useEffect
 } from 'react';
-import { flip, offset } from '@floating-ui/dom';
+import { flip, offset, shift } from '@floating-ui/dom';
 import { TooltipAreaEvent } from './TooltipAreaEvent';
 import {
   ChartDataTypes,
@@ -18,6 +18,7 @@ import {
   ChartInternalNestedDataShape
 } from '@/common/data';
 import {
+  getParentSVG,
   getPositionForTarget,
   getClosestContinousScalePoint,
   getClosestBandScalePoint
@@ -140,6 +141,16 @@ export interface TooltipAreaProps {
    * @default 2 * Math.PI
    */
   endAngle?: number;
+
+  /**
+   * Whether to constrain the tooltip to the chart's container, sliding it
+   * along the chart's edges instead of overflowing at first/last points.
+   * When enabled, modifiers set on the tooltip element are honored and the
+   * containment middleware is appended to them.
+   *
+   * @default false
+   */
+  constrainToContainer?: boolean;
 }
 
 interface TooltipDataShape {
@@ -148,6 +159,10 @@ interface TooltipDataShape {
   data?: ChartDataTypes | Array<ChartDataTypes | ChartInternalShallowDataShape>;
   i?: number;
 }
+
+// floating-ui middleware are stateless descriptors, safe to share across instances
+const DEFAULT_OFFSET_MODIFIERS = [offset({ mainAxis: 15 })];
+const DEFAULT_MODIFIERS = [...DEFAULT_OFFSET_MODIFIERS, flip()];
 
 // eslint-disable-next-line react/display-name
 export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
@@ -172,7 +187,8 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
       placement: placementProp,
       onValueLeave = () => undefined,
       startAngle = 0,
-      endAngle = 2 * Math.PI
+      endAngle = 2 * Math.PI,
+      constrainToContainer = false
     },
     childRef
   ) => {
@@ -599,6 +615,26 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
       );
     }, [height, onMouseMove, width]);
 
+    // The boundary must be an HTML element — SVG elements yield a degenerate
+    // clipping rect — so use the element wrapping the chart's root svg. Until
+    // the ref is set it stays undefined (`?? undefined` coerces null, which
+    // floating-ui does not treat as absent) and floating-ui falls back to its
+    // default viewport boundary.
+    const boundary = ref.current
+      ? (getParentSVG({ target: ref.current })?.parentElement ?? undefined)
+      : undefined;
+    const modifiers = useMemo(
+      () =>
+        constrainToContainer
+          ? [
+              ...(tooltip.props.modifiers || DEFAULT_OFFSET_MODIFIERS),
+              flip({ boundary }),
+              shift({ boundary, padding: 4, crossAxis: true })
+            ]
+          : DEFAULT_MODIFIERS,
+      [constrainToContainer, tooltip.props.modifiers, boundary]
+    );
+
     return (
       <Fragment>
         {disabled && children}
@@ -610,7 +646,7 @@ export const TooltipArea = forwardRef<any, Partial<TooltipAreaProps>>(
               element={tooltip}
               visible={visible}
               placement={placement}
-              modifiers={[offset({ mainAxis: 15 }), flip()]}
+              modifiers={modifiers}
               reference={tooltipReference}
               color={color}
               value={value}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Tooltip on the corners may going out of viewport

Issue Number: N/A


## What is the new behavior?
Tooltip stays inside view port with constrainToContainer props

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

- Introduced TooltipArea component to manage tooltips in AreaChart.
- Added `constrainToContainer` prop to allow tooltips to slide within chart boundaries.
- Updated AreaChartMultiSeries story to demonstrate the new constrained tooltip behavior.
